### PR TITLE
Fixup: Remove old references to @bufbuild/protoc-gen-connect-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -188,10 +188,6 @@
       "resolved": "packages/protoc-gen-connect-es",
       "link": true
     },
-    "node_modules/@bufbuild/protoc-gen-connect-web": {
-      "resolved": "packages/protoc-gen-connect-web",
-      "link": true
-    },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-1.0.0.tgz",
@@ -4707,7 +4703,6 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.14.0",
-        "@bufbuild/protoc-gen-connect-web": "^0.7.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
         "@types/express": "^4.17.15",
         "esbuild": "^0.16.12",
@@ -4741,14 +4736,6 @@
         "@bufbuild/protoc-gen-es": {
           "optional": true
         }
-      }
-    },
-    "packages/protoc-gen-connect-web": {
-      "name": "@bufbuild/protoc-gen-connect-web",
-      "version": "0.0.1",
-      "dev": true,
-      "dependencies": {
-        "@bufbuild/protoplugin": "^1.0.0"
       }
     }
   },
@@ -4895,7 +4882,6 @@
         "@bufbuild/connect-node": "^0.7.0",
         "@bufbuild/connect-web": "^0.7.0",
         "@bufbuild/protobuf": "^1.0.0",
-        "@bufbuild/protoc-gen-connect-web": "^0.7.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
         "@types/express": "^4.17.15",
         "esbuild": "^0.16.12",
@@ -4911,12 +4897,6 @@
     },
     "@bufbuild/protoc-gen-connect-es": {
       "version": "file:packages/protoc-gen-connect-es",
-      "requires": {
-        "@bufbuild/protoplugin": "^1.0.0"
-      }
-    },
-    "@bufbuild/protoc-gen-connect-web": {
-      "version": "file:packages/protoc-gen-connect-web",
       "requires": {
         "@bufbuild/protoplugin": "^1.0.0"
       }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.14.0",
-    "@bufbuild/protoc-gen-connect-web": "^0.7.0",
     "@bufbuild/protoc-gen-es": "^1.0.0",
     "@types/express": "^4.17.15",
     "esbuild": "^0.16.12",


### PR DESCRIPTION
There were some references left to the old plugin name. 