### PR TITLE
Move polyfill dep to connect-node

### DIFF
--- a/packages/connect-node-test/package.json
+++ b/packages/connect-node-test/package.json
@@ -23,7 +23,6 @@
     "@types/long": "^5.0.0",
     "esbuild": "^0.16.12",
     "fastify": "^4.13.0",
-    "headers-polyfill": "^3.1.2",
     "jasmine": "^4.5.0",
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "^1.6.0",

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -26,7 +26,8 @@
     "node": ">=16.0.0 <19"
   },
   "dependencies": {
-    "@bufbuild/connect": "0.7.0"
+    "@bufbuild/connect": "0.7.0",
+    "headers-polyfill": "^3.1.2"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.0.0"

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/bufbuild/connect-es.git",
     "directory": "packages/connect-node"
   },
-  "sideEffects": false,
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",


### PR DESCRIPTION
This moves the `header-polyfill` dependency to connect-node where it is actually used.