### PR TITLE
Declare type exports

### DIFF
--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -18,9 +18,9 @@
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "engines": {
     "node": ">=16.0.0 <19"

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -18,9 +18,9 @@
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "engines": {
     "node": ">=16.0.0 <19"

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -17,9 +17,9 @@
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "engines": {
     "node": ">=16.0.0 <19"

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -19,9 +19,9 @@
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "dependencies": {
     "@bufbuild/connect": "0.7.0"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -47,6 +47,22 @@
       "require": "./dist/cjs/protocol-grpc-web/index.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "protocol": [
+        "./dist/types/protocol/index.d.ts"
+      ],
+      "protocol-connect": [
+        "./dist/types/protocol-connect/index.d.ts"
+      ],
+      "protocol-grpc": [
+        "./dist/types/protocol-grpc/index.d.ts"
+      ],
+      "protocol-grpc-web": [
+        "./dist/types/protocol-grpc-web/index.d.ts"
+      ]
+    }
+  },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.0.0"
   },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -19,21 +19,22 @@
   },
   "main": "./dist/cjs/index.js",
   "type": "module",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     },
     "./protocol": {
+      "types": "./dist/types/protocol/index.d.ts",
       "import": "./dist/esm/protocol/index.js",
-      "require": "./dist/cjs/protocol/index.js",
-      "types": "./dist/types/protocol/index.d.ts"
+      "require": "./dist/cjs/protocol/index.js"
     },
     "./protocol-connect": {
+      "types": "./dist/types/protocol-connect/index.d.ts",
       "import": "./dist/esm/protocol-connect/index.js",
-      "require": "./dist/cjs/protocol-connect/index.js",
-      "types": "./dist/types/protocol-connect/index.d.ts"
+      "require": "./dist/cjs/protocol-connect/index.js"
     },
     "./protocol-grpc": {
       "import": "./dist/esm/protocol-grpc/index.js",
@@ -41,26 +42,9 @@
       "types": "./dist/types/protocol-grpc/index.d.ts"
     },
     "./protocol-grpc-web": {
+      "types": "./dist/types/protocol-grpc-web/index.d.ts",
       "import": "./dist/esm/protocol-grpc-web/index.js",
-      "require": "./dist/cjs/protocol-grpc-web/index.js",
-      "types": "./dist/types/protocol-grpc-web/index.d.ts"
-    }
-  },
-  "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "protocol": [
-        "./dist/types/protocol/index.d.ts"
-      ],
-      "protocol-connect": [
-        "./dist/types/protocol-connect/index.d.ts"
-      ],
-      "protocol-grpc": [
-        "./dist/types/protocol-grpc/index.d.ts"
-      ],
-      "protocol-grpc-web": [
-        "./dist/types/protocol-grpc-web/index.d.ts"
-      ]
+      "require": "./dist/cjs/protocol-grpc-web/index.js"
     }
   },
   "peerDependencies": {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -37,9 +37,9 @@
       "require": "./dist/cjs/protocol-connect/index.js"
     },
     "./protocol-grpc": {
+      "types": "./dist/types/protocol-grpc/index.d.ts",
       "import": "./dist/esm/protocol-grpc/index.js",
-      "require": "./dist/cjs/protocol-grpc/index.js",
-      "types": "./dist/types/protocol-grpc/index.d.ts"
+      "require": "./dist/cjs/protocol-grpc/index.js"
     },
     "./protocol-grpc-web": {
       "types": "./dist/types/protocol-grpc-web/index.d.ts",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -22,23 +22,28 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./protocol": {
       "import": "./dist/esm/protocol/index.js",
-      "require": "./dist/cjs/protocol/index.js"
+      "require": "./dist/cjs/protocol/index.js",
+      "types": "./dist/types/protocol/index.d.ts"
     },
     "./protocol-connect": {
       "import": "./dist/esm/protocol-connect/index.js",
-      "require": "./dist/cjs/protocol-connect/index.js"
+      "require": "./dist/cjs/protocol-connect/index.js",
+      "types": "./dist/types/protocol-connect/index.d.ts"
     },
     "./protocol-grpc": {
       "import": "./dist/esm/protocol-grpc/index.js",
-      "require": "./dist/cjs/protocol-grpc/index.js"
+      "require": "./dist/cjs/protocol-grpc/index.js",
+      "types": "./dist/types/protocol-grpc/index.d.ts"
     },
     "./protocol-grpc-web": {
       "import": "./dist/esm/protocol-grpc-web/index.js",
-      "require": "./dist/cjs/protocol-grpc-web/index.js"
+      "require": "./dist/cjs/protocol-grpc-web/index.js",
+      "types": "./dist/types/protocol-grpc-web/index.d.ts"
     }
   },
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Type exports for the connect package are currently not explicitly specified.

- Adds explicit type exports for every entrypoint of the `connect` package.
- Puts the type exports for all packages first (in accordance with the documentation: https://www.typescriptlang.org/docs/handbook/esm-node.html)
- Removes `typesVersions` which shouldn't be necessary afaik (please correct me if I'm missing sth.)