### PR TITLE
Re-add a deprecated protoc-gen-connect-web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ $(BUILD)/protoc-gen-connect-es: node_modules tsconfig.base.json packages/protoc-
 	@mkdir -p $(@D)
 	@touch $(@)
 
+$(BUILD)/protoc-gen-connect-web: node_modules tsconfig.base.json packages/protoc-gen-connect-web/tsconfig.json $(shell find packages/protoc-gen-connect-web/src -name '*.ts')
+	npm run -w packages/protoc-gen-connect-web clean
+	npm run -w packages/protoc-gen-connect-web build
+	@mkdir -p $(@D)
+	@touch $(@)
+
 $(BUILD)/connect: $(GEN)/connect node_modules tsconfig.base.json packages/connect/tsconfig.json $(shell find packages/connect/src -name '*.ts') packages/connect/*.js
 	npm run -w packages/connect clean
 	npm run -w packages/connect build
@@ -147,7 +153,7 @@ clean: crosstestserverstop ## Delete build artifacts and installed dependencies
 	git clean -Xdf
 
 .PHONY: build
-build: $(BUILD)/connect $(BUILD)/connect-web $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/protoc-gen-connect-es $(BUILD)/example ## Build
+build: $(BUILD)/connect $(BUILD)/connect-web $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/protoc-gen-connect-es $(BUILD)/protoc-gen-connect-web $(BUILD)/example ## Build
 
 .PHONY: test
 test: testcore testnode testwebnode testwebbrowser ## Run all tests, except browserstack
@@ -234,7 +240,8 @@ release: all ## Release npm packages
 		--workspace packages/connect-fastify \
 		--workspace packages/connect-express \
 		--workspace packages/connect \
-		--workspace packages/protoc-gen-connect-es
+		--workspace packages/protoc-gen-connect-es \
+		--workspace packages/protoc-gen-connect-web \
 
 .PHONY: crosstestserverstop
 crosstestserverstop:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "workspaces": [
         "./packages/connect",
         "./packages/protoc-gen-connect-es",
+        "./packages/protoc-gen-connect-web",
         "./packages/connect-web",
         "./packages/connect-node",
         "./packages/connect-fastify",
@@ -191,6 +192,10 @@
     },
     "node_modules/@bufbuild/protoc-gen-connect-es": {
       "resolved": "packages/protoc-gen-connect-es",
+      "link": true
+    },
+    "node_modules/@bufbuild/protoc-gen-connect-web": {
+      "resolved": "packages/protoc-gen-connect-web",
       "link": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
@@ -5097,7 +5102,8 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/connect": "0.7.0"
+        "@bufbuild/connect": "0.7.0",
+        "headers-polyfill": "^3.1.2"
       },
       "engines": {
         "node": ">=16.0.0 <19"
@@ -5121,7 +5127,6 @@
         "esbuild": "^0.16.12",
         "express": "^4.18.2",
         "fastify": "^4.13.0",
-        "headers-polyfill": "^3.1.2",
         "jasmine": "^4.5.0",
         "karma": "^6.4.1",
         "karma-browserstack-launcher": "^1.6.0",
@@ -5209,11 +5214,37 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@bufbuild/connect-web": "0.7.0",
+        "@bufbuild/connect": "0.7.0",
         "@bufbuild/protoc-gen-es": "^1.0.0"
       },
       "peerDependenciesMeta": {
-        "@bufbuild/connect-web": {
+        "@bufbuild/connect": {
+          "optional": true
+        },
+        "@bufbuild/protoc-gen-es": {
+          "optional": true
+        }
+      }
+    },
+    "packages/protoc-gen-connect-web": {
+      "name": "@bufbuild/protoc-gen-connect-web",
+      "version": "0.7.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protoplugin": "^1.0.0"
+      },
+      "bin": {
+        "protoc-gen-connect-web": "bin/protoc-gen-connect-web"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/connect": "*",
+        "@bufbuild/protoc-gen-es": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/connect": {
           "optional": true
         },
         "@bufbuild/protoc-gen-es": {
@@ -5307,7 +5338,8 @@
     "@bufbuild/connect-node": {
       "version": "file:packages/connect-node",
       "requires": {
-        "@bufbuild/connect": "0.7.0"
+        "@bufbuild/connect": "0.7.0",
+        "headers-polyfill": "^3.1.2"
       }
     },
     "@bufbuild/connect-node-test": {
@@ -5325,7 +5357,6 @@
         "esbuild": "^0.16.12",
         "express": "^4.18.2",
         "fastify": "^4.13.0",
-        "headers-polyfill": "^3.1.2",
         "jasmine": "^4.5.0",
         "karma": "^6.4.1",
         "karma-browserstack-launcher": "^1.6.0",
@@ -5396,6 +5427,12 @@
     },
     "@bufbuild/protoc-gen-connect-es": {
       "version": "file:packages/protoc-gen-connect-es",
+      "requires": {
+        "@bufbuild/protoplugin": "^1.0.0"
+      }
+    },
+    "@bufbuild/protoc-gen-connect-web": {
+      "version": "file:packages/protoc-gen-connect-web",
       "requires": {
         "@bufbuild/protoplugin": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "workspaces": [
     "./packages/connect",
     "./packages/protoc-gen-connect-es",
+    "./packages/protoc-gen-connect-web",
     "./packages/connect-web",
     "./packages/connect-node",
     "./packages/connect-fastify",

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 106,950 b | 46,872 b | 12,535 b |
+| connect        | 106,960 b | 46,880 b | 12,515 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,226 b |

--- a/packages/protoc-gen-connect-web/README.md
+++ b/packages/protoc-gen-connect-web/README.md
@@ -1,0 +1,39 @@
+# @bufbuild/protoc-gen-connect-web
+
+This package is deprecated.
+
+The code generator `protoc-gen-connect-web` can now be used for Connect on the 
+Web, and for Connect on Node.js.  
+For a better fit, we have renamed it to `protoc-gen-connect-es` in 
+[v0.8.0](https://github.com/bufbuild/connect-es/releases/tag/v0.8.0). 
+
+The generated code is actually exactly the same, so it is not necessary to 
+update right away, but we are not going to maintain this package anymore.
+
+Switching to [@bufbuild/protoc-gen-connect-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es) 
+is straight-forward:
+
+```bash
+npm remove @bufbuild/protoc-gen-connect-web
+npm install @bufbuild/protoc-gen-connect-es
+```
+
+Update your `buf.gen.yaml`:
+
+```diff
+version: v1
+plugins:
+  - name: es
+    out: src/gen
+-  - name: connect-web
++  - name: connect-es
+    out: src/gen
+```
+
+And your import paths:
+
+```diff
+- import { ElizaService } from "gen/eliza_connectweb";
++ import { ElizaService } from "gen/eliza_connect";
+```
+

--- a/packages/protoc-gen-connect-web/bin/protoc-gen-connect-web
+++ b/packages/protoc-gen-connect-web/bin/protoc-gen-connect-web
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+const {runNodeJs} = require("@bufbuild/protoplugin");
+const {protocGenConnectWeb} = require("../dist/cjs/src/protoc-gen-connect-web-plugin.js");
+
+runNodeJs(protocGenConnectWeb);

--- a/packages/protoc-gen-connect-web/package.json
+++ b/packages/protoc-gen-connect-web/package.json
@@ -1,15 +1,14 @@
 {
-  "name": "@bufbuild/protoc-gen-connect-es",
+  "name": "@bufbuild/protoc-gen-connect-web",
   "version": "0.7.0",
-  "description": "Code generator for Connect",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bufbuild/connect-es.git",
-    "directory": "packages/protoc-gen-connect-es"
+    "directory": "packages/protoc-gen-connect-web"
   },
   "bin": {
-    "protoc-gen-connect-es": "bin/protoc-gen-connect-es"
+    "protoc-gen-connect-web": "bin/protoc-gen-connect-web"
   },
   "engines": {
     "node": ">=14"
@@ -23,7 +22,7 @@
     "@bufbuild/protoplugin": "^1.0.0"
   },
   "peerDependencies": {
-    "@bufbuild/connect": "0.7.0",
+    "@bufbuild/connect": "*",
     "@bufbuild/protoc-gen-es": "^1.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/protoc-gen-connect-web/src/declaration.ts
+++ b/packages/protoc-gen-connect-web/src/declaration.ts
@@ -1,0 +1,60 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescService } from "@bufbuild/protobuf";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
+import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
+import {
+  literalString,
+  makeJsDoc,
+  localName,
+} from "@bufbuild/protoplugin/ecmascript";
+
+export function generateDts(schema: Schema) {
+  for (const protoFile of schema.files) {
+    if (protoFile.services.length == 0) {
+      continue;
+    }
+    const file = schema.generateFile(protoFile.name + "_connectweb.d.ts");
+    file.preamble(protoFile);
+    for (const service of protoFile.services) {
+      generateService(schema, file, service);
+    }
+  }
+}
+
+// prettier-ignore
+function generateService(schema: Schema, f: GeneratedFile, service: DescService) {
+  const { MethodKind: rtMethodKind, MethodIdempotency: rtMethodIdempotency } = schema.runtime;
+  f.print(makeJsDoc(service));
+  f.print("export declare const ", localName(service), ": {");
+  f.print(`  readonly typeName: `, literalString(service.typeName), `,`);
+  f.print("  readonly methods: {");
+  for (const method of service.methods) {
+    f.print(makeJsDoc(method, "    "));
+    f.print("    readonly ", localName(method), ": {");
+    f.print(`      readonly name: `, literalString(method.name), `,`);
+    f.print("      readonly I: typeof ", method.input, ",");
+    f.print("      readonly O: typeof ", method.output, ",");
+    f.print("      readonly kind: ", rtMethodKind, ".", MethodKind[method.methodKind], ",");
+    if (method.idempotency !== undefined) {
+      f.print("      readonly idempotency: ", rtMethodIdempotency, ".", MethodIdempotency[method.idempotency], ",");
+    }
+    // In case we start supporting options, we have to surface them here
+    f.print("    },");
+  }
+  f.print("  }");
+  f.print("};");
+  f.print();
+}

--- a/packages/protoc-gen-connect-web/src/javascript.ts
+++ b/packages/protoc-gen-connect-web/src/javascript.ts
@@ -1,0 +1,60 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescService } from "@bufbuild/protobuf";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
+import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
+import {
+  literalString,
+  makeJsDoc,
+  localName,
+} from "@bufbuild/protoplugin/ecmascript";
+
+export function generateJs(schema: Schema) {
+  for (const protoFile of schema.files) {
+    if (protoFile.services.length == 0) {
+      continue;
+    }
+    const file = schema.generateFile(protoFile.name + "_connectweb.js");
+    file.preamble(protoFile);
+    for (const service of protoFile.services) {
+      generateService(schema, file, service);
+    }
+  }
+}
+
+// prettier-ignore
+function generateService(schema: Schema, f: GeneratedFile, service: DescService) {
+ const { MethodKind: rtMethodKind, MethodIdempotency: rtMethodIdempotency } = schema.runtime;
+  f.print(makeJsDoc(service));
+  f.print("export const ", localName(service), " = {");
+  f.print(`  typeName: `, literalString(service.typeName), `,`);
+  f.print("  methods: {");
+  for (const method of service.methods) {
+    f.print(makeJsDoc(method, "    "));
+    f.print("    ", localName(method), ": {");
+    f.print(`      name: `, literalString(method.name), `,`);
+    f.print("      I: ", method.input, ",");
+    f.print("      O: ", method.output, ",");
+    f.print("      kind: ", rtMethodKind, ".", MethodKind[method.methodKind], ",");
+    if (method.idempotency !== undefined) {
+        f.print("      idempotency: ", rtMethodIdempotency, ".", MethodIdempotency[method.idempotency], ",");
+    }
+    // In case we start supporting options, we have to surface them here
+    f.print("    },");
+  }
+  f.print("  }");
+  f.print("};");
+  f.print();
+}

--- a/packages/protoc-gen-connect-web/src/protoc-gen-connect-web-plugin.ts
+++ b/packages/protoc-gen-connect-web/src/protoc-gen-connect-web-plugin.ts
@@ -1,0 +1,27 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import { generateTs } from "./typescript.js";
+import { generateJs } from "./javascript.js";
+import { generateDts } from "./declaration.js";
+import { version } from "../package.json";
+
+export const protocGenConnectWeb = createEcmaScriptPlugin({
+  name: "protoc-gen-connect-web",
+  version: `v${String(version)}`,
+  generateTs,
+  generateJs,
+  generateDts,
+});

--- a/packages/protoc-gen-connect-web/src/typescript.ts
+++ b/packages/protoc-gen-connect-web/src/typescript.ts
@@ -1,0 +1,77 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescService } from "@bufbuild/protobuf";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
+import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
+import {
+  literalString,
+  makeJsDoc,
+  localName,
+} from "@bufbuild/protoplugin/ecmascript";
+
+export function generateTs(schema: Schema) {
+  for (const protoFile of schema.files) {
+    if (protoFile.services.length == 0) {
+      continue;
+    }
+    const file = schema.generateFile(protoFile.name + "_connectweb.ts");
+    file.preamble(protoFile);
+    for (const service of protoFile.services) {
+      generateService(schema, file, service);
+    }
+  }
+}
+
+// prettier-ignore
+function generateService(
+  schema: Schema,
+  f: GeneratedFile,
+  service: DescService
+) {
+  const { MethodKind: rtMethodKind, MethodIdempotency: rtMethodIdempotency } =
+    schema.runtime;
+  f.print(makeJsDoc(service));
+  f.print("export const ", localName(service), " = {");
+  f.print(`  typeName: `, literalString(service.typeName), `,`);
+  f.print("  methods: {");
+  for (const method of service.methods) {
+    f.print(makeJsDoc(method, "    "));
+    f.print("    ", localName(method), ": {");
+    f.print(`      name: `, literalString(method.name), `,`);
+    f.print("      I: ", method.input, ",");
+    f.print("      O: ", method.output, ",");
+    f.print(
+      "      kind: ",
+      rtMethodKind,
+      ".",
+      MethodKind[method.methodKind],
+      ","
+    );
+    if (method.idempotency !== undefined) {
+      f.print(
+        "    idempotency: ",
+        rtMethodIdempotency,
+        ".",
+        MethodIdempotency[method.idempotency],
+        ","
+      );
+    }
+    // In case we start supporting options, we have to surface them here
+    f.print("    },");
+  }
+  f.print("  }");
+  f.print("} as const;");
+  f.print();
+}

--- a/packages/protoc-gen-connect-web/tsconfig.json
+++ b/packages/protoc-gen-connect-web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": ["src/protoc-gen-connect-web-plugin.ts"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
`protoc-gen-connect-web` has a peer dependency on `@bufbuild/connect-web` v0.7.0.  
This forces users of the upcoming release to update the code generator right away. 

We think it will be a _much_ more gentle upgrade for our users to keep `protoc-gen-connect-web` alive for the upcoming release, and switch to the renamed code generator `protoc-gen-connect-web` at their leisure.