### PR TITLE
Fix: Revert to binary serialization by default for gRPC-web

### DIFF
--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -115,7 +115,7 @@ export function createGrpcWebTransport(
   options: GrpcWebTransportOptions
 ): Transport {
   assertFetchApi();
-  const useBinaryFormat = options.useBinaryFormat ?? false;
+  const useBinaryFormat = options.useBinaryFormat ?? true;
   return {
     async unary<
       I extends Message<I> = AnyMessage,


### PR DESCRIPTION
[v0.8.0](https://github.com/bufbuild/connect-es/releases/tag/v0.8.0) made an inadvertent change to the gRPC-web transport from @bufbuild/connect-web, changing behavior to use the JSON format by default.

This reverts to previous default behavior, because not all gRPC-web servers support JSON.