### PR TITLE
Add two separate links to the tutorials for web and node

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/bufbuild/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/connect/latest?color=green&label=%40bufbuild%2Fconnect)](https://www.npmjs.com/package/@bufbuild/connect) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protoc-gen-connect-es/latest?color=green&label=%40bufbuild%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.  
-[@bufbuild/connect](https://www.npmjs.com/package/@bufbuild/connect) brings them to TypeScript, 
+[@bufbuild/connect](https://www.npmjs.com/package/@bufbuild/connect) brings them to TypeScript,
 the web browser, and to Node.js.
 
 With Connect, you define your schema first:
@@ -24,9 +24,9 @@ console.log(answer);
 // {sentence: 'When you feel happy, what do you do?'}
 ```
 
-Unlike REST, the RPCs you use with Connect are typesafe end to end, but they are
-regular HTTP under the hood. You can see all requests in the network inspector,
-and you can `curl` them if you want:
+Unlike REST, the Remote Procedure Call are type-safe, but they are regular HTTP 
+under the hood. You can see all requests in the network inspector, and you 
+can `curl` them if you want:
 
 ```shell
 curl \
@@ -35,45 +35,62 @@ curl \
     https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say
 ```
 
-With Connect for ECMAScript, you can spin up a service in Node.js and call it
-from the web, the terminal, or native mobile clients. Under the hood, it uses
-[Protocol Buffers](https://github.com/bufbuild/protobuf-es) for the schema, and
-implements RPC (remote procedure calls) with three protocols: The widely available
-gRPC and gRPC-web, and Connect's [own protocol](https://connect.build/docs/protocol/),
-optimized for the web. This gives you unparalleled interoperability with
-full-stack type-safety.
-
-To get started, head over to the [docs](https://connect.build/docs/web/getting-started)
-for a tutorial. You will also find API documentation and best practices there.
-For using Connect with your favorite frontend framework, take a look at
-[connect-es-integration](https://github.com/bufbuild/connect-es-integration).
+Connect uses [Protocol Buffers](https://github.com/bufbuild/protobuf-es) for the 
+schema, and implements RPC with three protocols: The widely available gRPC and 
+gRPC-web protocols, and Connect's [own protocol](https://connect.build/docs/protocol/),
+optimized for the web. This gives you unparalleled interoperability across many
+platforms and languages, with type-safety end-to-end.
 
 
-## Packages
+## Get started on the web
 
-- [@bufbuild/connect](https://www.npmjs.com/package/@bufbuild/connect-web):
-  RPC clients and servers for your schema ([source code](packages/connect-web)).
-- [@bufbuild/protoc-gen-connect-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es):
-  Code generator plugin for the services in your schema ([source code](packages/protoc-gen-connect-es)).
+Follow our [10 minute tutorial](https://connect.build/docs/web/getting-started) where
+we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
+web interface for ELIZA.
+
+**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/bufbuild/connect-es-integration)), 
+and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
+We support all modern web browsers that implement the widely available
+[fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).
 
 
-## Supported Platforms
+## Get started on Node.js
 
-- We support all modern web browsers that implement the widely available
-  [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
-  and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).  
-  **React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported, and 
-  an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
-- On Node.js, we use the `http`, `https`, or `http2` modules, and support v16, v17 and v18.  
-  You can spin up a vanilla Node.js servers, or use our plugin for [Fastify](https://www.fastify.io/),
-  or for [Express](https://expressjs.com/).
-- The libraries and the generated code are compatible with ES2017 and TypeScript 4.1.
+Follow our [10 minute tutorial](https://connect.build/docs/node/getting-started)
+to spin up service in Node.js, and call it from the web, and from a gRPC client 
+in your terminal.
+
+You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/) 
+or [Express](https://expressjs.com/). We support the builtin `http`, and `http2` 
+modules on Node.js v16, v17 and v18.
+
+
+## Other platforms
 
 Would you like to use Connect on other platforms like Bun, Deno, Vercel’s Edge Runtime,
 or Cloudflare Workers? We’d love to learn about your use cases and what you’d like to do
 with Connect. You can reach us either through the [Buf Slack](https://buf.build/links/slack/)
 or by filing a [GitHub issue](https://github.com/bufbuild/connect-web/issues) and we’d
 be more than happy to chat!
+
+
+## Packages
+
+- [@bufbuild/connect](https://www.npmjs.com/package/@bufbuild/connect):
+  RPC clients and servers for your schema ([source code](packages/connect)).
+- [@bufbuild/protoc-gen-connect-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es):
+  Code generator plugin for the services in your schema ([source code](packages/protoc-gen-connect-es)).
+- [@bufbuild/connect-web](https://www.npmjs.com/package/@bufbuild/connect-web):
+  Adapters for web browsers, and any other platform that has the fetch API on board.
+- [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-node):
+  Serve RPCs on vanilla Node.js servers. Call RPCs with any protocol.
+- [@bufbuild/connect-fastify](https://www.npmjs.com/package/@bufbuild/connect-fastify):
+  Plug your services into a [Fastify](https://www.fastify.io/) server.
+- [@bufbuild/connect-express](https://www.npmjs.com/package/@bufbuild/connect-express):
+  Adds your services to an [Express](https://expressjs.com/) server.
+
+The libraries and the generated code are compatible with ES2017 and TypeScript 4.1.
 
 
 ## Ecosystem

--- a/packages/protoc-gen-connect-es/README.md
+++ b/packages/protoc-gen-connect-es/README.md
@@ -25,8 +25,9 @@ npm install @bufbuild/connect @bufbuild/protobuf
 
 If you want to call Connect or gRPC-web services from a web browsers, make sure to install 
 [@bufbuild/connect-web](https://www.npmjs.com/package/@bufbuild/connect-web). If you want servers too, 
-install [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-node) or
-[@bufbuild/connect-fastify](https://www.npmjs.com/package/@bufbuild/connect-fastify).
+install [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-node),
+[@bufbuild/connect-fastify](https://www.npmjs.com/package/@bufbuild/connect-fastify), or
+[@bufbuild/connect-express](https://www.npmjs.com/package/@bufbuild/connect-express)
 
 We use peer dependencies to ensure that code generator and runtime library are
 compatible with each other. Note that yarn and pnpm only emit a warning in this case.


### PR DESCRIPTION
This adds two "Get started" sections to the top-level readme. One for web, one for node.