### PR TITLE
Remove error from polyfill

### DIFF
--- a/packages/connect-node/src/node-headers-polyfill.ts
+++ b/packages/connect-node/src/node-headers-polyfill.ts
@@ -18,14 +18,13 @@ import { Headers as HeadersPolyfill } from "headers-polyfill";
 // --experimental-fetch flag. It became available by default with Node
 // v18.0.0.
 // If this code runs in Node < 18, it installs an alternative
-// implementation.
+// implementation if one has not already been polyfilled.
 
 const [major] = process.versions.node
   .split(".")
   .map((value) => parseInt(value, 10));
 if (major < 18) {
-  if (typeof globalThis.Headers != "undefined") {
-    throw "expected Headers to be undeclared in node " + process.versions.node;
+  if (typeof globalThis.Headers === "undefined") {
+    globalThis.Headers = HeadersPolyfill as unknown as typeof Headers;
   }
-  globalThis.Headers = HeadersPolyfill as unknown as typeof Headers;
 }


### PR DESCRIPTION
Fixes #509.

Previously the Node `Headers` polyfill was throwing an error if the Node version was < 18 and `Headers` was defined.  However, this doesn't account for users of the library who have already polyfilled `Headers`.  

This removes the error from being thrown and just returns the global `Headers` if defined.