### PR TITLE
Update "Getting started" section in the @bufbuild/connect README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding
 ## Get started on Node.js
 
 Follow our [10 minute tutorial](https://connect.build/docs/node/getting-started)
-to spin up service in Node.js, and call it from the web, and from a gRPC client 
+to spin up a service in Node.js, and call it from the web, and from a gRPC client 
 in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/) 

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -42,71 +42,71 @@ import {
 
 export {
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   createPromiseClient,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   createCallbackClient,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   CallbackClient,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   PromiseClient,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   CallOptions,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   Transport,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   ConnectError,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   connectErrorDetails,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   connectErrorFromReason,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   Code,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   Interceptor,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   UnaryRequest,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   UnaryResponse,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   StreamRequest,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   StreamResponse,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   encodeBinaryHeader,
   /**
-   * @deprecated please import from @bufbuild/connect instead
+   * @deprecated please import from \@bufbuild/connect instead
    */
   decodeBinaryHeader,
 };

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -57,7 +57,7 @@ and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding
 ## Get started on Node.js
 
 Follow our [10 minute tutorial](https://connect.build/docs/node/getting-started)
-to spin up service in Node.js, and call it from the web, and from a gRPC client
+to spin up a service in Node.js, and call it from the web, and from a gRPC client
 in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/)

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -41,11 +41,25 @@ optimized for the web. This gives you unparalleled interoperability with
 full-stack type-safety.
 
 
-## Getting started
+## Get started on the web
 
-To get started with Connect, head over to the [docs](https://connect.build/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+Follow our [10 minute tutorial](https://connect.build/docs/web/getting-started) where
+we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
+web interface for ELIZA.
 
-Connect plays nice with Vue, Svelte, Remix, Next.js, Angular and many others. Take a look at
-[our examples](https://github.com/bufbuild/connect-es-integration) for various frameworks.
+**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/bufbuild/connect-es-integration)),
+and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
+We support all modern web browsers that implement the widely available
+[fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).
 
+
+## Get started on Node.js
+
+Follow our [10 minute tutorial](https://connect.build/docs/node/getting-started)
+to spin up service in Node.js, and call it from the web, and from a gRPC client
+in your terminal.
+
+You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/)
+or [Express](https://expressjs.com/). We support the builtin `http`, and `http2`
+modules on Node.js v16, v17 and v18.


### PR DESCRIPTION
This replaces the "Getting started" section in the README.md of @bufbuild/connect with the sections "Get started on the web" and "Get started on Node.js" we added in https://github.com/bufbuild/connect-es/pull/495.

It also fixes some deprecation messages by escaping at-signs - thanks to @dimitropoulos for the shout.