### PR TITLE
Add missing JSDoc for new handler and transport options

### DIFF
--- a/packages/connect-node/src/compression.ts
+++ b/packages/connect-node/src/compression.ts
@@ -23,6 +23,12 @@ const gunzip = promisify(zlib.gunzip);
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
+/**
+ * The gzip compression algorithm, implemented with the Node.js built-in module
+ * zlib. This value can be used for the `sendCompression` and `acceptCompression`
+ * option of client transports, or for the `acceptCompression` option of server
+ * plugins like `fastifyConnectPlugin` from @bufbuild/connect-fastify.
+ */
 export const compressionGzip: Compression = {
   name: "gzip",
   compress(bytes) {
@@ -38,6 +44,12 @@ export const compressionGzip: Compression = {
   },
 };
 
+/**
+ * The brotli compression algorithm, implemented with the Node.js built-in module
+ * zlib. This value can be used for the `sendCompression` and `acceptCompression`
+ * option of client transports, or for the `acceptCompression` option of server
+ * plugins like `fastifyConnectPlugin` from @bufbuild/connect-fastify.
+ */
 export const compressionBrotli: Compression = {
   name: "br",
   compress(bytes) {

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -94,13 +94,6 @@ type ConnectTransportOptions = (
    */
   useBinaryFormat?: boolean;
 
-  // TODO document
-  acceptCompression?: Compression[];
-  sendCompression?: Compression;
-  compressMinBytes?: number;
-  readMaxBytes?: number;
-  writeMaxBytes?: number;
-
   /**
    * Interceptors that should be applied to all calls running through
    * this transport. See the Interceptor type for details.
@@ -116,6 +109,55 @@ type ConnectTransportOptions = (
    * Options for the binary wire format.
    */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+
+  /**
+   * Compression algorithms available to a client. Clients ask servers to
+   * compress responses using any of the registered algorithms. The first
+   * registered algorithm is the most preferred.
+   *
+   * It is safe to use this option liberally: servers will ignore any
+   * compression algorithms they don't support. To compress requests, pair this
+   * option with `sendCompression`.
+   *
+   * If this option is not provided, the compression algorithms "gzip" and "br"
+   * (Brotli) are accepted. To opt out of response compression, pass an
+   * empty array.
+   */
+  acceptCompression?: Compression[];
+
+  /**
+   * Configures the client to use the specified algorithm to compress request
+   * messages.
+   *
+   * Because some servers don't support compression, clients default to sending
+   * uncompressed requests.
+   */
+  sendCompression?: Compression;
+
+  /**
+   * Sets a minimum size threshold for compression: Messages that are smaller
+   * than the configured minimum are sent uncompressed.
+   *
+   * The default value is 1 kibibyte, because the CPU cost of compressing very
+   * small messages usually isn't worth the small reduction in network I/O.
+   */
+  compressMinBytes?: number;
+
+  /**
+   * Limits the performance impact of pathologically large messages sent by the
+   * server. Limits apply to each individual message, not to the stream as a
+   * whole.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  readMaxBytes?: number;
+
+  /**
+   * Prevents sending messages too large for the server to handle.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  writeMaxBytes?: number;
 };
 
 /**

--- a/packages/connect-node/src/grpc-transport.ts
+++ b/packages/connect-node/src/grpc-transport.ts
@@ -104,14 +104,54 @@ type GrpcTransportOptions = (
    */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  // TODO document
+  /**
+   * Compression algorithms available to a client. Clients ask servers to
+   * compress responses using any of the registered algorithms. The first
+   * registered algorithm is the most preferred.
+   *
+   * It is safe to use this option liberally: servers will ignore any
+   * compression algorithms they don't support. To compress requests, pair this
+   * option with `sendCompression`.
+   *
+   * If this option is not provided, the compression algorithms "gzip" and "br"
+   * (Brotli) are accepted. To opt out of response compression, pass an
+   * empty array.
+   */
   acceptCompression?: Compression[];
-  sendCompression?: Compression;
-  compressMinBytes?: number;
-  readMaxBytes?: number;
-  writeMaxBytes?: number;
 
-  keepSessionAlive?: boolean;
+  /**
+   * Configures the client to use the specified algorithm to compress request
+   * messages.
+   *
+   * Because some servers don't support compression, clients default to sending
+   * uncompressed requests.
+   */
+  sendCompression?: Compression;
+
+  /**
+   * Sets a minimum size threshold for compression: Messages that are smaller
+   * than the configured minimum are sent uncompressed.
+   *
+   * The default value is 1 kibibyte, because the CPU cost of compressing very
+   * small messages usually isn't worth the small reduction in network I/O.
+   */
+  compressMinBytes?: number;
+
+  /**
+   * Limits the performance impact of pathologically large messages sent by the
+   * server. Limits apply to each individual message, not to the stream as a
+   * whole.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  readMaxBytes?: number;
+
+  /**
+   * Prevents sending messages too large for the server to handle.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  writeMaxBytes?: number;
 };
 
 /**

--- a/packages/connect-node/src/grpc-web-transport.ts
+++ b/packages/connect-node/src/grpc-web-transport.ts
@@ -106,14 +106,54 @@ type GrpcWebTransportOptions = (
    */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  // TODO document
+  /**
+   * Compression algorithms available to a client. Clients ask servers to
+   * compress responses using any of the registered algorithms. The first
+   * registered algorithm is the most preferred.
+   *
+   * It is safe to use this option liberally: servers will ignore any
+   * compression algorithms they don't support. To compress requests, pair this
+   * option with `sendCompression`.
+   *
+   * If this option is not provided, the compression algorithms "gzip" and "br"
+   * (Brotli) are accepted. To opt out of response compression, pass an
+   * empty array.
+   */
   acceptCompression?: Compression[];
-  sendCompression?: Compression;
-  compressMinBytes?: number;
-  readMaxBytes?: number;
-  writeMaxBytes?: number;
 
-  keepSessionAlive?: boolean;
+  /**
+   * Configures the client to use the specified algorithm to compress request
+   * messages.
+   *
+   * Because some servers don't support compression, clients default to sending
+   * uncompressed requests.
+   */
+  sendCompression?: Compression;
+
+  /**
+   * Sets a minimum size threshold for compression: Messages that are smaller
+   * than the configured minimum are sent uncompressed.
+   *
+   * The default value is 1 kibibyte, because the CPU cost of compressing very
+   * small messages usually isn't worth the small reduction in network I/O.
+   */
+  compressMinBytes?: number;
+
+  /**
+   * Limits the performance impact of pathologically large messages sent by the
+   * server. Limits apply to each individual message, not to the stream as a
+   * whole.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  readMaxBytes?: number;
+
+  /**
+   * Prevents sending messages too large for the server to handle.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
+  writeMaxBytes?: number;
 };
 
 /**

--- a/packages/connect-node/src/validate-node-transport-options.ts
+++ b/packages/connect-node/src/validate-node-transport-options.ts
@@ -32,41 +32,137 @@ import {
   createNodeHttp2Client,
 } from "./node-universal-client.js";
 
+
+/**
+ * Options specific to the Node.js built in http and https modules.
+ */
 export interface NodeHttp1TransportOptions {
   httpVersion: "1.1";
 
-  // TODO document
+  /**
+   * Options passed to the request() call of the Node.js built-in
+   * http or https module.
+   */
   nodeOptions?:
     | Omit<http.RequestOptions, "signal">
     | Omit<https.RequestOptions, "signal">;
 }
 
+/**
+ * Options specific to the Node.js built in http2 module.
+ */
 export interface NodeHttp2TransportOptions {
   httpVersion: "2";
 
-  // TODO document
+  /**
+   * Options passed to the connect() call of the Node.js built-in
+   * http2 module.
+   */
   nodeOptions?: http2.ClientSessionOptions | http2.SecureClientSessionOptions;
 
-  // TODO document
+  /**
+   * By default, HTTP/2 sessions are terminated after each request.
+   * Set this option to true to keep sessions alive across multiple
+   * requests.
+   */
   keepSessionAlive?: boolean;
 }
 
+/**
+ * Options that are common to all client transports for Node.js.
+ */
 type CommonNodeTransportOptions = (
   | NodeHttp1TransportOptions
   | NodeHttp2TransportOptions
 ) & {
+  /**
+   * Base URI for all HTTP requests.
+   *
+   * Requests will be made to <baseUrl>/<package>.<service>/method
+   *
+   * Example: `baseUrl: "https://example.com/my-api"`
+   *
+   * This will make a `POST /my-api/my_package.MyService/Foo` to
+   * `example.com` via HTTPS.
+   */
   baseUrl: string;
+
+  /**
+   * By default, clients use the binary format for gRPC-web, because
+   * not all gRPC-web implementations support JSON.
+   */
   useBinaryFormat?: boolean;
+
+  /**
+   * Interceptors that should be applied to all calls running through
+   * this transport. See the Interceptor type for details.
+   */
   interceptors?: Interceptor[];
+
+  /**
+   * Options for the JSON format.
+   */
   jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+
+  /**
+   * Options for the binary wire format.
+   */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+
+  /**
+   * Compression algorithms available to a client. Clients ask servers to
+   * compress responses using any of the registered algorithms. The first
+   * registered algorithm is the most preferred.
+   *
+   * It is safe to use this option liberally: servers will ignore any
+   * compression algorithms they don't support. To compress requests, pair this
+   * option with `sendCompression`.
+   *
+   * If this option is not provided, the compression algorithms "gzip" and "br"
+   * (Brotli) are accepted. To opt out of response compression, pass an
+   * empty array.
+   */
   acceptCompression?: Compression[];
+
+  /**
+   * Configures the client to use the specified algorithm to compress request
+   * messages.
+   *
+   * Because some servers don't support compression, clients default to sending
+   * uncompressed requests.
+   */
   sendCompression?: Compression;
+
+  /**
+   * Sets a minimum size threshold for compression: Messages that are smaller
+   * than the configured minimum are sent uncompressed.
+   *
+   * The default value is 1 kibibyte, because the CPU cost of compressing very
+   * small messages usually isn't worth the small reduction in network I/O.
+   */
   compressMinBytes?: number;
+
+  /**
+   * Limits the performance impact of pathologically large messages sent by the
+   * server. Limits apply to each individual message, not to the stream as a
+   * whole.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
   readMaxBytes?: number;
+
+  /**
+   * Prevents sending messages too large for the server to handle.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
   writeMaxBytes?: number;
 };
 
+/**
+ * Asserts that the options are within sane limits, and returns default values
+ * where no value is provided.
+ */
 export function validateNodeTransportOptions(
   options: CommonNodeTransportOptions
 ) {

--- a/packages/connect-node/src/validate-node-transport-options.ts
+++ b/packages/connect-node/src/validate-node-transport-options.ts
@@ -32,7 +32,6 @@ import {
   createNodeHttp2Client,
 } from "./node-universal-client.js";
 
-
 /**
  * Options specific to the Node.js built in http and https modules.
  */

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -56,16 +56,44 @@ interface MI<
   readonly idempotency?: MethodIdempotency;
 }
 
-// TODO document
+/**
+ * Context for an RPC on the server. Every RPC implementation can accept a
+ * HandlerContext as an argument, and
+ */
 export interface HandlerContext {
+
+  /**
+   * Metadata for the method being called.
+   */
   readonly method: MethodInfo;
+
+  /**
+   * Metadata for the service being called.
+   */
   readonly service: ServiceType;
+
+  /**
+   * Incoming request headers.
+   */
   readonly requestHeader: Headers;
+
+  /**
+   * Outgoing response headers.
+   *
+   * For methods that return a stream, response headers must be set before
+   * yielding the first response message.
+   */
   readonly responseHeader: Headers;
+
+  /**
+   * Outgoing response trailers.
+   */
   readonly responseTrailer: Headers;
 }
 
-// TODO document
+/**
+ * Create a new HandlerContext.
+ */
 export function createHandlerContext(
   spec: { service: ServiceType; method: MethodInfo },
   requestHeader: HeadersInit,

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -61,7 +61,6 @@ interface MI<
  * HandlerContext as an argument, and
  */
 export interface HandlerContext {
-
   /**
    * Metadata for the method being called.
    */

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -58,7 +58,7 @@ interface MI<
 
 /**
  * Context for an RPC on the server. Every RPC implementation can accept a
- * HandlerContext as an argument, and
+ * HandlerContext as an argument to gain access to headers and service metadata.
  */
 export interface HandlerContext {
   /**

--- a/packages/connect/src/protocol/async-iterable.ts
+++ b/packages/connect/src/protocol/async-iterable.ts
@@ -300,7 +300,6 @@ export function pipeTo(
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  // TODO should this be pipe(iterable, ... ???
   iterable = pipe(iterable, ...transforms, { propagateDownStreamError: false });
 
   return sink(iterable).catch((reason) => {

--- a/packages/connect/src/protocol/limit-io.ts
+++ b/packages/connect/src/protocol/limit-io.ts
@@ -23,10 +23,17 @@ import { Code } from "../code.js";
 const maxReadMaxBytes = 0xffffffff;
 const maxWriteMaxBytes = maxReadMaxBytes;
 
+/**
+ * The default value for the compressMinBytes option. The CPU cost of compressing
+ * very small messages usually isn't worth the small reduction in network I/O, so
+ * the default value is 1 kibibyte.
+ */
 const defaultCompressMinBytes = 1024;
 
 /**
- * Asserts that the options writeMaxBytes and readMaxBytes are in sane.
+ * Asserts that the options writeMaxBytes, readMaxBytes, and compressMinBytes
+ * are within sane limits, and returns default values where no value is
+ * provided.
  */
 export function validateReadWriteMaxBytes(
   readMaxBytes: number | undefined,

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -38,14 +38,52 @@ import type { Compression } from "./compression.js";
 import type { ProtocolHandlerFactory } from "./protocol-handler-factory.js";
 import { validateReadWriteMaxBytes } from "./limit-io.js";
 
-// TODO document
+/**
+ * Common options for handlers.
+ */
 export interface UniversalHandlerOptions {
+
+  /**
+   * Compression algorithms available to a server for decompressing request
+   * messages, and for compressing response messages.
+   */
   acceptCompression: Compression[];
+
+  /**
+   * Sets a minimum size threshold for compression: Messages that are smaller
+   * than the configured minimum are sent uncompressed.
+   *
+   * The default value is 1 kibibyte, because the CPU cost of compressing very
+   * small messages usually isn't worth the small reduction in network I/O.
+   */
   compressMinBytes: number;
+
+  /**
+   * Limits the performance impact of pathologically large messages sent by the
+   * client. Limits apply to each individual message, not to the stream as a
+   * whole.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
   readMaxBytes: number;
+
+  /**
+   * Prevents sending messages too large for the client to handle.
+   *
+   * The default limit is the maximum supported value of ~4GiB.
+   */
   writeMaxBytes: number;
+
+  /**
+   * Options for the JSON format.
+   */
   jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+
+  /**
+   * Options for the binary wire format.
+   */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+
   maxDeadlineDurationMs: number; // TODO TCN-785
   shutdownSignal: AbortSignal; // TODO TCN-919
   // TODO
@@ -92,7 +130,13 @@ export interface UniversalHandler extends UniversalHandlerFn {
 
 const neverSignal = new AbortController().signal;
 
-// TODO document
+
+/**
+ * Asserts that the options are within sane limits, and returns default values
+ * where no value is provided.
+ *
+ * Note that this function does not set default values for `acceptCompression`.
+ */
 export function validateUniversalHandlerOptions(
   opt: Partial<UniversalHandlerOptions> | undefined
 ): UniversalHandlerOptions {
@@ -104,7 +148,6 @@ export function validateUniversalHandlerOptions(
       opt.writeMaxBytes,
       opt.compressMinBytes
     ),
-    compressMinBytes: opt.compressMinBytes ?? 0,
     jsonOptions: opt.jsonOptions,
     binaryOptions: opt.binaryOptions,
     maxDeadlineDurationMs: Number.MAX_SAFE_INTEGER,

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -42,7 +42,6 @@ import { validateReadWriteMaxBytes } from "./limit-io.js";
  * Common options for handlers.
  */
 export interface UniversalHandlerOptions {
-
   /**
    * Compression algorithms available to a server for decompressing request
    * messages, and for compressing response messages.
@@ -129,7 +128,6 @@ export interface UniversalHandler extends UniversalHandlerFn {
 }
 
 const neverSignal = new AbortController().signal;
-
 
 /**
  * Asserts that the options are within sane limits, and returns default values

--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -64,12 +64,55 @@ export interface ConnectRouter {
   ): this;
 }
 
+/**
+ * Options for a ConnectRouter. By default, all three protocols gRPC, gRPC-web,
+ * and Connect are enabled.
+ */
 export interface ConnectRouterOptions extends Partial<UniversalHandlerOptions> {
+  /**
+   * Enable the gRPC protocol and make your API available to all gRPC clients
+   * for various platforms and languages. See https://grpc.io/
+   *
+   * The protocol is enabled by default. Set this option to `false` to disable
+   * it, but mind that at least one protocol must be enabled.
+   *
+   * Note that gRPC is typically served with TLS over HTTP/2 and requires access
+   * to HTTP trailers.
+   */
   grpc?: boolean;
+
+  /**
+   * Enable the gRPC-web protocol and make your API available to all gRPC-web
+   * clients. gRCP-web is commonly used in web browsers, but there are client
+   * implementations for other platforms as well, for example in Dart, Kotlin,
+   * and Swift. See https://github.com/grpc/grpc-web
+   *
+   * The protocol is enabled by default. Set this option to `false` to disable
+   * it, but mind that at least one protocol must be enabled.
+   *
+   * gRPC-web works over HTTP 1.1 or HTTP/2 and does not require access to HTTP
+   * trailers. Note that bidi streaming requires HTTP/2, and web browsers may
+   * not support all streaming types.
+   */
   grpcWeb?: boolean;
+
+  /**
+   * Enable the Connect protocol and make your API available to all Connect
+   * clients, but also for a simple call with curl. See https://connect.build/
+   *
+   * The protocol is enabled by default. Set this option to `false` to disable
+   * it, but mind that at least one protocol must be enabled.
+   *
+   * Connect works over HTTP 1.1 or HTTP/2 and does not require access to HTTP
+   * trailers. Note that bidi streaming requires HTTP/2, and web browsers may
+   * not support all streaming types.
+   */
   connect?: boolean;
 }
 
+/**
+ * Create a new ConnectRouter.
+ */
 export function createConnectRouter(
   routerOptions?: ConnectRouterOptions
 ): ConnectRouter {


### PR DESCRIPTION
This adds documentation for several new options for client transports and servers that were added in the last weeks.