### PR TITLE
Fix npm v9 packlist

### DIFF
--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -34,6 +34,6 @@
     "@bufbuild/protobuf": "^1.0.0"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ]
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -34,6 +34,6 @@
     "@bufbuild/protobuf": "^1.0.0"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ]
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -32,6 +32,6 @@
     "@bufbuild/protobuf": "^1.0.0"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ]
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -29,6 +29,6 @@
     "@bufbuild/protobuf": "^1.0.0"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ]
 }


### PR DESCRIPTION
npm v9 changed how it parses its include/ignore lists, see https://github.com/npm/cli/issues/5853#issuecomment-1317760279. 

Where it would previously include all files within the `dist` directory with the following setting:

```json
  "files": [
    "dist/**/"
  ]
```

In v9.5.0, this pattern matches nothing.

This led to some packages of release v0.8.2 to be published empty, which we addressed by publishing v0.8.2-1 of the affected packages (`@bufbuild/connect-node`, `@bufbuild/connect-fastify`, `@bufbuild/connect-express`, and `@bufbuild/connect-web`).

This PR updates the pattern to work with npm v9, verified by running `npm pack` with and without the change.