### PR TITLE
Remove unused dependencies from the internal test package for Node.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5137,12 +5137,7 @@
         "esbuild": "^0.16.12",
         "express": "^4.18.2",
         "fastify": "^4.13.0",
-        "jasmine": "^4.5.0",
-        "karma": "^6.4.1",
-        "karma-browserstack-launcher": "^1.6.0",
-        "karma-chrome-launcher": "^3.1.1",
-        "karma-esbuild": "^2.2.5",
-        "karma-jasmine": "^5.1.0"
+        "jasmine": "^4.5.0"
       }
     },
     "packages/connect-node-test/node_modules/@types/long": {
@@ -5369,12 +5364,7 @@
         "esbuild": "^0.16.12",
         "express": "^4.18.2",
         "fastify": "^4.13.0",
-        "jasmine": "^4.5.0",
-        "karma": "^6.4.1",
-        "karma-browserstack-launcher": "^1.6.0",
-        "karma-chrome-launcher": "^3.1.1",
-        "karma-esbuild": "^2.2.5",
-        "karma-jasmine": "^5.1.0"
+        "jasmine": "^4.5.0"
       },
       "dependencies": {
         "@types/long": {

--- a/packages/connect-node-test/package.json
+++ b/packages/connect-node-test/package.json
@@ -26,11 +26,6 @@
     "esbuild": "^0.16.12",
     "express": "^4.18.2",
     "fastify": "^4.13.0",
-    "jasmine": "^4.5.0",
-    "karma": "^6.4.1",
-    "karma-browserstack-launcher": "^1.6.0",
-    "karma-chrome-launcher": "^3.1.1",
-    "karma-esbuild": "^2.2.5",
-    "karma-jasmine": "^5.1.0"
+    "jasmine": "^4.5.0"
   }
 }


### PR DESCRIPTION
`packages/connect-node-test` was copied from `packages/connect-web-test` and still depends on packages for running tests in web browsers. 

We only need these dependencies for the web tests and can safely remove them from the test package for Node.js.