### PR TITLE
Fix the gRPC User-Agent header name

### DIFF
--- a/packages/connect/src/protocol-grpc-web/headers.ts
+++ b/packages/connect/src/protocol-grpc-web/headers.ts
@@ -12,4 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "../protocol-grpc/headers.js";
+export {
+  headerContentType,
+  headerEncoding,
+  headerAcceptEncoding,
+  headerTimeout,
+  headerGrpcStatus,
+  headerGrpcMessage,
+  headerStatusDetailsBin,
+} from "../protocol-grpc/headers.js";
+
+/**
+ * gRPC-web does not use the standard header User-Agent.
+ */
+export const headerXUserAgent = "X-User-Agent";
+
+/**
+ * The canonical grpc/grpc-web JavaScript implementation sets
+ * this request header with value "1".
+ * Some servers may rely on the header to identify gRPC-web
+ * requests. For example the proxy by improbable:
+ * https://github.com/improbable-eng/grpc-web/blob/53aaf4cdc0fede7103c1b06f0cfc560c003a5c41/go/grpcweb/wrapper.go#L231
+ */
+export const headerXGrpcWeb = "X-Grpc-Web";

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -18,7 +18,8 @@ import {
   headerContentType,
   headerEncoding,
   headerTimeout,
-  headerUserAgent,
+  headerXUserAgent,
+  headerXGrpcWeb,
 } from "./headers.js";
 import { contentTypeJson, contentTypeProto } from "./content-type.js";
 
@@ -37,14 +38,11 @@ export function requestHeader(
     headerContentType,
     useBinaryFormat ? contentTypeProto : contentTypeJson
   );
-  // Some servers may rely on the request header `X-Grpc-Web` to identify
-  // gRPC-web requests. For example the proxy by improbable:
-  // https://github.com/improbable-eng/grpc-web/blob/53aaf4cdc0fede7103c1b06f0cfc560c003a5c41/go/grpcweb/wrapper.go#L231
-  result.set("X-Grpc-Web", "1");
+  result.set(headerXGrpcWeb, "1");
   // Note that we do not comply with recommended structure for the
   // user-agent string.
   // https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
-  result.set(headerUserAgent, "@bufbuild/connect-web");
+  result.set(headerXUserAgent, "@bufbuild/connect-web");
   if (timeoutMs !== undefined) {
     result.set(headerTimeout, `${timeoutMs}m`);
   }

--- a/packages/connect/src/protocol-grpc/headers.ts
+++ b/packages/connect/src/protocol-grpc/headers.ts
@@ -19,4 +19,5 @@ export const headerTimeout = "Grpc-Timeout";
 export const headerGrpcStatus = "Grpc-Status";
 export const headerGrpcMessage = "Grpc-Message";
 export const headerStatusDetailsBin = "Grpc-Status-Details-Bin";
-export const headerUserAgent = "X-User-Agent";
+export const headerUserAgent = "User-Agent";
+export const headerMessageType = "Grpc-Message-Type";

--- a/packages/connect/src/protocol-grpc/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc/request-header.spec.ts
@@ -31,10 +31,10 @@ describe("requestHeader", () => {
     expect(listHeaderKeys(headers)).toEqual([
       "content-type",
       "te",
-      "x-user-agent",
+      "user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc+proto");
-    expect(headers.get("X-User-Agent")).toBe("@bufbuild/connect-web");
+    expect(headers.get("User-Agent")).toBe("@bufbuild/connect-web");
   });
 
   it("should create request headers with timeout", () => {
@@ -43,7 +43,7 @@ describe("requestHeader", () => {
       "content-type",
       "grpc-timeout",
       "te",
-      "x-user-agent",
+      "user-agent",
     ]);
     expect(headers.get("Grpc-Timeout")).toBe("10m");
   });
@@ -67,7 +67,7 @@ describe("requestHeader", () => {
       "grpc-accept-encoding",
       "grpc-encoding",
       "te",
-      "x-user-agent",
+      "user-agent",
     ]);
     expect(headers.get(headerEncoding)).toBe(compressionMock.name);
     expect(headers.get(headerAcceptEncoding)).toBe(compressionMock.name);


### PR DESCRIPTION
The gRPC-web protocol uses `X-User-Agent`, but gRCP uses the standard header `User-Agent`.

The gRCP transports mistakenly set the `X-User-Agent` header, like the gRCP-web transport. This PR corrects that mistake to use `User-Agent` instead.