### PR TITLE
Fix `unhandledRejection` when aborting a server stream using @bufbuild/connect-node

### DIFF
--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -328,7 +328,10 @@ function h2Request(
           session.close();
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        // We intentionally swallow sentinel rejection - errors must 
+        // propagate through the request or response iterables.
+      });
     const stream = session.request(
       {
         ...headers,

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -321,12 +321,14 @@ function h2Request(
     session.off("error", sentinel.reject);
     session.off("error", h2SessionConnectError);
     session.on("error", sentinel.reject);
-    sentinel.finally(() => {
-      session.off("error", sentinel.reject);
-      if (!sessionHolder.keepOpen) {
-        session.close();
-      }
-    });
+    sentinel
+      .finally(() => {
+        session.off("error", sentinel.reject);
+        if (!sessionHolder.keepOpen) {
+          session.close();
+        }
+      })
+      .catch(() => {});
     const stream = session.request(
       {
         ...headers,


### PR DESCRIPTION
Hello ! :smile: 

I think I have solved the issue #476. If I understood correctly, the call `sentinel.finally()` returns a new `Promise`, whose failure was never catched.

However, I am not sure that ignoring the error is the right solution. I have the impression that the `sentinel.catch()` earlier in the code makes it safe to do so, but am I wrong?

Thank you very much in advance!