### PR TITLE
Fix socket connect issue in Node 19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GEN   = .tmp/gen
 CROSSTEST_VERSION := 2c228a09c52e3a95263034c1fb79119d33ab3258
 LICENSE_HEADER_YEAR_RANGE := 2021-2023
 LICENSE_IGNORE := -e .tmp\/ -e node_modules\/ -e packages\/.*\/src\/gen\/ -e packages\/.*\/dist\/ -e scripts\/
+NODE19_VERSION ?= v19.2.0
 NODE18_VERSION ?= v18.2.0
 NODE17_VERSION ?= v17.0.0
 NODE16_VERSION ?= v16.0.0
@@ -27,6 +28,13 @@ node_modules/.bin/protoc-gen-es: node_modules
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(BIN)) go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.1.0
+
+$(BIN)/node19: Makefile
+	@mkdir -p $(@D)
+	curl -sSL https://nodejs.org/dist/$(NODE19_VERSION)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz | tar xJ -C $(TMP) node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
+	mv $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
+	rm -r $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	@touch $(@)
 
 $(BIN)/node18: Makefile
 	@mkdir -p $(@D)
@@ -163,11 +171,12 @@ testcore: $(BUILD)/connect
 	npm run -w packages/connect jasmine
 
 .PHONY: testnode
-testnode: $(BIN)/node16 $(BIN)/node17 $(BIN)/node18 $(BUILD)/connect-node-test
+testnode: $(BIN)/node16 $(BIN)/node17 $(BIN)/node18 $(BIN)/node19 $(BUILD)/connect-node-test
 	$(MAKE) crosstestserverrun
 	cd packages/connect-node-test && PATH="$(abspath $(BIN)):$(PATH)" node16 --trace-warnings ../../node_modules/.bin/jasmine --config=jasmine.json
 	cd packages/connect-node-test && PATH="$(abspath $(BIN)):$(PATH)" node17 --trace-warnings ../../node_modules/.bin/jasmine --config=jasmine.json
 	cd packages/connect-node-test && PATH="$(abspath $(BIN)):$(PATH)" node18 --trace-warnings ../../node_modules/.bin/jasmine --config=jasmine.json
+	cd packages/connect-node-test && PATH="$(abspath $(BIN)):$(PATH)" node19 --trace-warnings ../../node_modules/.bin/jasmine --config=jasmine.json
 	$(MAKE) crosstestserverstop
 
 .PHONY: testwebnode

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -23,7 +23,7 @@
     "require": "./dist/cjs/index.js"
   },
   "engines": {
-    "node": ">=16.0.0 <19"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@bufbuild/connect": "0.8.3",

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -23,7 +23,7 @@
     "require": "./dist/cjs/index.js"
   },
   "engines": {
-    "node": ">=16.0.0 <19"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@bufbuild/connect": "0.8.3",

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -23,7 +23,7 @@
     "require": "./dist/cjs/index.js"
   },
   "engines": {
-    "node": ">=16.0.0 <19"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@bufbuild/connect": "0.8.3",

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -22,7 +22,7 @@
     "require": "./dist/cjs/index.js"
   },
   "engines": {
-    "node": ">=16.0.0 <19"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@bufbuild/connect": "0.8.3",

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -177,11 +177,18 @@ function h1Request(
       sentinel.reject(new ConnectError("node socket timed out", Code.Aborted))
     );
     request.off("socket", onRequestSocket);
-    socket.on("connect", onSocketConnect);
 
     function onSocketConnect() {
       socket.off("connect", onSocketConnect);
       onRequest(request);
+    }
+
+    // If readyState is open, then socket is already open due to keepAlive, so
+    // the 'connect' event will never fire so call onRequest explicitly
+    if (socket.readyState === "open") {
+      onRequest(request);
+    } else {
+      socket.on("connect", onSocketConnect);
     }
   });
 }

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -172,12 +172,6 @@ function h1Request(
     sentinel.reject(new ConnectError("node request aborted", Code.Aborted))
   );
   request.on("socket", function onRequestSocket(socket: net.Socket) {
-    socket.on("error", sentinel.reject);
-    socket.on("timeout", () =>
-      sentinel.reject(new ConnectError("node socket timed out", Code.Aborted))
-    );
-    request.off("socket", onRequestSocket);
-
     function onSocketConnect() {
       socket.off("connect", onSocketConnect);
       onRequest(request);


### PR DESCRIPTION
Node 19 turns on `keepAlive` by default when using a global `Agent` for HTTP/1.1.  This in turn causes our sockets to be pooled and reused.  

We issue the request in the socket's `connect` event, but, since the sockets are being reused, the `connect` event doesn't fire.  So, the request is never sent and the socket times out.

This checks the socket's `readyState` to see if it is `open` and if so, it simply issues the request. Otherwise, it binds the even listener to the socket's `connect` event.

Checking `readyState` should be the best way to verify the socket's connection. See code [here](https://github.com/nodejs/node/blob/4ae7c7a00258cd0ac2bb344afcaa57a2b2d2ed3f/lib/net.js#LL652C26-L652C26).