### PR TITLE
Enable the test cancel_after_begin

### DIFF
--- a/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
+++ b/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
@@ -17,14 +17,7 @@ import { TestService } from "../gen/grpc/testing/test_connect.js";
 import { PayloadType } from "../gen/grpc/testing/messages_pb.js";
 import { createTestServers } from "../helpers/testserver.js";
 
-// TODO(TCN-919)
-/*
-  When we run the test individually against one or two servers the test past
-  however, when ran against the entire test suite this test fails with an
-  Unhandled promise rejection: AbortError: The operation was aborted, error.
-  will investigate later on
-*/
-xdescribe("cancel_after_begin", function () {
+describe("cancel_after_begin", function () {
   const servers = createTestServers();
   beforeAll(async () => await servers.start());
 

--- a/packages/connect-node/src/connect-node-adapter.ts
+++ b/packages/connect-node/src/connect-node-adapter.ts
@@ -14,6 +14,7 @@
 
 import {
   Code,
+  connectErrorFromReason,
   ConnectRouter,
   ConnectRouterOptions,
   createConnectRouter,
@@ -27,7 +28,6 @@ import {
   universalRequestFromNodeRequest,
   universalResponseToNodeResponse,
 } from "./node-universal-handler.js";
-import { connectErrorFromNodeReason } from "./node-error.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 
 interface ConnectNodeAdapterOptions extends ConnectRouterOptions {
@@ -91,7 +91,7 @@ export function connectNodeAdapter(
     uHandler(uReq)
       .then((uRes) => universalResponseToNodeResponse(uRes, res))
       .catch((reason) => {
-        if (connectErrorFromNodeReason(reason).code == Code.Aborted) {
+        if (connectErrorFromReason(reason).code == Code.Aborted) {
           return;
         }
         // eslint-disable-next-line no-console

--- a/packages/connect-node/src/node-error.ts
+++ b/packages/connect-node/src/node-error.ts
@@ -56,7 +56,11 @@ export function connectErrorFromNodeReason(reason: unknown): ConnectError {
     // This behavior is covered by the crosstest "unresolvable_host".
     code = Code.Unavailable;
   }
-  return connectErrorFromReason(reason, code);
+  const ce = connectErrorFromReason(reason, code);
+  if (ce !== reason) {
+    ce.cause = reason;
+  }
+  return ce;
 }
 
 /**

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -104,71 +104,67 @@ export function universalRequestFromNodeRequest(
  * on Node.js. Please be careful using this function in your own code, as we
  * may have to make changes to it in the future.
  */
-export function universalResponseToNodeResponse(
+export async function universalResponseToNodeResponse(
   universalResponse: UniversalServerResponse,
   nodeResponse: NodeServerResponse
 ): Promise<void> {
-  // return universalResponseToNodeResponseInternal(universalResponse, nodeResponse);
-  return universalResponseToNodeResponseInternal(
-    universalResponse,
-    nodeResponse
-  ).catch((e) => {
-    return Promise.reject(connectErrorFromNodeReason(e));
-  });
-}
-
-async function universalResponseToNodeResponseInternal(
-  universalResponse: UniversalServerResponse,
-  nodeResponse: NodeServerResponse
-): Promise<void> {
-  if (universalResponse.body instanceof Uint8Array) {
-    nodeResponse.writeHead(
-      universalResponse.status,
-      webHeaderToNodeHeaders(universalResponse.header)
-    );
-    await write(nodeResponse, universalResponse.body);
-  } else if (universalResponse.body !== undefined) {
-    for await (const chunk of universalResponse.body) {
-      // we deliberately send headers *in* this loop, not before,
-      // because we have to give the implementation a chance to
-      // set response headers
-      if (!nodeResponse.headersSent) {
-        nodeResponse.writeHead(
-          universalResponse.status,
-          webHeaderToNodeHeaders(universalResponse.header)
-        );
-      }
-      await write(nodeResponse, chunk);
-      if ("flush" in nodeResponse && typeof nodeResponse.flush == "function") {
-        // The npm package "compression" is an express middleware that is widely used,
-        // for example in next.js. It uses the npm package "compressible" to determine
-        // whether to apply compression to a response. Unfortunately, "compressible"
-        // matches every mime type that ends with "+json", causing our server-streaming
-        // RPCs to be buffered.
-        // The package modifies the response object, and adds a flush() method, which
-        // flushes the underlying gzip or deflate stream from the Node.js zlib module.
-        // The method is added here:
-        // https://github.com/expressjs/compression/blob/ad5113b98cafe1382a0ece30bb4673707ac59ce7/index.js#L70
-        nodeResponse.flush();
+  try {
+    if (universalResponse.body instanceof Uint8Array) {
+      nodeResponse.writeHead(
+        universalResponse.status,
+        webHeaderToNodeHeaders(universalResponse.header)
+      );
+      await write(nodeResponse, universalResponse.body);
+    } else if (universalResponse.body !== undefined) {
+      for await (const chunk of universalResponse.body) {
+        // we deliberately send headers *in* this loop, not before,
+        // because we have to give the implementation a chance to
+        // set response headers
+        if (!nodeResponse.headersSent) {
+          nodeResponse.writeHead(
+            universalResponse.status,
+            webHeaderToNodeHeaders(universalResponse.header)
+          );
+        }
+        await write(nodeResponse, chunk);
+        if (
+          "flush" in nodeResponse &&
+          typeof nodeResponse.flush == "function"
+        ) {
+          // The npm package "compression" is an express middleware that is widely used,
+          // for example in next.js. It uses the npm package "compressible" to determine
+          // whether to apply compression to a response. Unfortunately, "compressible"
+          // matches every mime type that ends with "+json", causing our server-streaming
+          // RPCs to be buffered.
+          // The package modifies the response object, and adds a flush() method, which
+          // flushes the underlying gzip or deflate stream from the Node.js zlib module.
+          // The method is added here:
+          // https://github.com/expressjs/compression/blob/ad5113b98cafe1382a0ece30bb4673707ac59ce7/index.js#L70
+          nodeResponse.flush();
+        }
       }
     }
+    if (!nodeResponse.headersSent) {
+      nodeResponse.writeHead(
+        universalResponse.status,
+        webHeaderToNodeHeaders(universalResponse.header)
+      );
+    }
+    if (universalResponse.trailer) {
+      nodeResponse.addTrailers(
+        webHeaderToNodeHeaders(universalResponse.trailer)
+      );
+      universalResponse.trailer;
+    }
+    await new Promise<void>((resolve) => {
+      // The npm package "compression" crashes when a callback is passed to end()
+      // https://github.com/expressjs/compression/blob/ad5113b98cafe1382a0ece30bb4673707ac59ce7/index.js#L115
+      nodeResponse.once("end", resolve);
+      nodeResponse.end();
+    });
+  } catch (e) {
+    throw connectErrorFromNodeReason(e);
   }
-  if (!nodeResponse.headersSent) {
-    nodeResponse.writeHead(
-      universalResponse.status,
-      webHeaderToNodeHeaders(universalResponse.header)
-    );
-  }
-  if (universalResponse.trailer) {
-    nodeResponse.addTrailers(webHeaderToNodeHeaders(universalResponse.trailer));
-    universalResponse.trailer;
-  }
-  await new Promise<void>((resolve) => {
-    // The npm package "compression" crashes when a callback is passed to end()
-    // https://github.com/expressjs/compression/blob/ad5113b98cafe1382a0ece30bb4673707ac59ce7/index.js#L115
-    nodeResponse.once("end", resolve);
-    nodeResponse.end();
-  });
 }
 
 async function* asyncIterableFromNodeServerRequest(

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -25,6 +25,7 @@ import {
   nodeHeaderToWebHeader,
   webHeaderToNodeHeaders,
 } from "./node-universal-header.js";
+import { connectErrorFromNodeReason } from "./node-error.js";
 
 /**
  * NodeHandlerFn is compatible with http.RequestListener and its equivalent
@@ -103,7 +104,20 @@ export function universalRequestFromNodeRequest(
  * on Node.js. Please be careful using this function in your own code, as we
  * may have to make changes to it in the future.
  */
-export async function universalResponseToNodeResponse(
+export function universalResponseToNodeResponse(
+  universalResponse: UniversalServerResponse,
+  nodeResponse: NodeServerResponse
+): Promise<void> {
+  // return universalResponseToNodeResponseInternal(universalResponse, nodeResponse);
+  return universalResponseToNodeResponseInternal(
+    universalResponse,
+    nodeResponse
+  ).catch((e) => {
+    return Promise.reject(connectErrorFromNodeReason(e));
+  });
+}
+
+async function universalResponseToNodeResponseInternal(
   universalResponse: UniversalServerResponse,
   nodeResponse: NodeServerResponse
 ): Promise<void> {


### PR DESCRIPTION
This PR enables the test case `cancel_after_begin`, which we can now pass thanks to https://github.com/bufbuild/connect-es/pull/530. It also makes sure we log internal errors in handlers, but not for errors caused by aborted requests.

(Should be merged after https://github.com/bufbuild/connect-es/pull/530)