### PR TITLE
Update Node support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/) 
 or [Express](https://expressjs.com/). We support the builtin `http`, and `http2` 
-modules on Node.js v16, v17, v18, and v19.
+modules on Node.js v16 and later.
 
 
 ## Other platforms

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/) 
 or [Express](https://expressjs.com/). We support the builtin `http`, and `http2` 
-modules on Node.js v16, v17 and v18.
+modules on Node.js v16, v17, v18, and v19.
 
 
 ## Other platforms

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -62,4 +62,4 @@ in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/)
 or [Express](https://expressjs.com/). We support the builtin `http`, and `http2`
-modules on Node.js v16, v17 and v18.
+modules on Node.js v16, v17, v18, and v19.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -62,4 +62,4 @@ in your terminal.
 
 You can use vanilla Node.js, or our server plugins for [Fastify](https://www.fastify.io/)
 or [Express](https://expressjs.com/). We support the builtin `http`, and `http2`
-modules on Node.js v16, v17, v18, and v19.
+modules on Node.js v16 and later.

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -10,7 +10,7 @@ You can find the protocol buffer schema [on the BSR](https://buf.build/bufbuild/
 
 ## Run the example
 
-You will need [Node](https://nodejs.org/en/download/) in version 16, 17, 18, or 19 installed. Download 
+You will need [Node](https://nodejs.org/en/download/) in version 16 or later installed. Download 
 the example project and install its dependencies:
 
 ```shell

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -10,7 +10,7 @@ You can find the protocol buffer schema [on the BSR](https://buf.build/bufbuild/
 
 ## Run the example
 
-You will need [Node](https://nodejs.org/en/download/) in version 16, 17, or 18 installed. Download 
+You will need [Node](https://nodejs.org/en/download/) in version 16, 17, 18, or 19 installed. Download 
 the example project and install its dependencies:
 
 ```shell


### PR DESCRIPTION
With #532, connect-es now officially supports Node v19.  This updates the docs to reflect that.