### PR TITLE
Add connect-next publish step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ release: all ## Release npm packages
 		--workspace packages/connect-node \
 		--workspace packages/connect-fastify \
 		--workspace packages/connect-express \
+		--workspace packages/connect-next \
 		--workspace packages/connect \
 		--workspace packages/protoc-gen-connect-es \
 		--workspace packages/protoc-gen-connect-web \


### PR DESCRIPTION
This adds a publish step for `connect-next` during `make release`.