### PR TITLE
Enable exactOptionalPropertyTypes

### DIFF
--- a/packages/connect/src/protocol-connect/end-stream.ts
+++ b/packages/connect/src/protocol-connect/end-stream.ts
@@ -34,7 +34,7 @@ export const endStreamFlag = 0b00000010;
  */
 export interface EndStreamResponse {
   metadata: Headers;
-  error?: ConnectError;
+  error?: ConnectError | undefined;
 }
 
 /**

--- a/packages/connect/src/protocol/compression.ts
+++ b/packages/connect/src/protocol/compression.ts
@@ -61,7 +61,7 @@ export function compressionNegotiate(
 ): {
   request: Compression | null;
   response: Compression | null;
-  error?: ConnectError;
+  error?: ConnectError | undefined;
 } {
   let request = null;
   let response = null;

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -77,12 +77,12 @@ export interface UniversalHandlerOptions {
   /**
    * Options for the JSON format.
    */
-  jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+  jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions> | undefined;
 
   /**
    * Options for the binary wire format.
    */
-  binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+  binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions> | undefined;
 
   maxDeadlineDurationMs: number; // TODO TCN-785
   shutdownSignal: AbortSignal; // TODO TCN-919

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "sourceMap": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
     "noImplicitThis": true,
     "useUnknownInCatchVariables": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
To quote from the TypeScript team lead:

> If we were to start TypeScript over again, we believe the behavior of strictOptionalProperties would be on by default
> https://github.com/microsoft/TypeScript/issues/44421

This [configuration](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) brings a pretty critical element to the type-soundness (critical because it drastically changes the behavior of operations that check for keys). [SameValueZero](https://262.ecma-international.org/7.0/#sec-samevaluezero) checks remain unchanged, anyway, so there's basically no downside to having this rule enabled. The https://github.com/microsoft/TypeScript/pull/43947 from Anders provides some more context, as well.

Thankfully, this codebase was already pretty close to the mark, with only a few little minor things to update to increase strictness. Note a similar PR: https://github.com/bufbuild/protobuf-es/pull/431