### PR TITLE
Add test setup for the @bufbuild/connect-node package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,15 @@ clean: crosstestserverstop ## Delete build artifacts and installed dependencies
 build: $(BUILD)/connect $(BUILD)/connect-web $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/connect-next $(BUILD)/protoc-gen-connect-es $(BUILD)/protoc-gen-connect-web $(BUILD)/example ## Build
 
 .PHONY: test
-test: testcore testnode testwebnode testwebbrowser ## Run all tests, except browserstack
+test: testconnectpackage testconnectnodepackage testnode testwebnode testwebbrowser ## Run all tests, except browserstack
 
-.PHONY: testcore
-testcore: $(BUILD)/connect
+.PHONY: testconnectpackage
+testconnectpackage: $(BUILD)/connect
 	npm run -w packages/connect jasmine
+
+.PHONY: testconnectnodepackage
+testconnectnodepackage: $(BUILD)/connect-node
+	npm run -w packages/connect-node jasmine
 
 .PHONY: testnode
 testnode: $(BIN)/node16 $(BIN)/node17 $(BIN)/node18 $(BIN)/node19 $(BUILD)/connect-node-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,21 +3662,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jasmine": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.5.0.tgz",
-      "integrity": "sha512-9olGRvNZyADIwYL9XBNBst5BTU/YaePzuddK+YRslc7rI9MdTIE4r3xaBKbv2GEmzYYUfMOdTR8/i6JfLZaxSQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.6.0.tgz",
+      "integrity": "sha512-iq7HQ5M8ydNUspjd9vbFW9Lu+6lQ1QLDIqjl0WysEllF5EJZy8XaUyNlhCJVwOx2YFzqTtARWbS56F/f0PzRFw==",
       "dependencies": {
         "glob": "^7.1.6",
-        "jasmine-core": "^4.5.0"
+        "jasmine-core": "^4.6.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
-      "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
+      "integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ=="
     },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
@@ -5541,6 +5541,10 @@
       "dependencies": {
         "@bufbuild/connect": "0.8.4",
         "headers-polyfill": "^3.1.2"
+      },
+      "devDependencies": {
+        "@types/jasmine": "^4.3.1",
+        "jasmine": "^4.6.0"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-node-test/package.json
+++ b/packages/connect-node-test/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/esm/*",
     "generate": "buf generate",
-    "build": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
-    "jasmine": "../../node_modules/.bin/jasmine --config=jasmine.json"
+    "build": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
+    "jasmine": "jasmine --config=jasmine.json"
   },
   "type": "module",
   "types": "./dist/types/index.d.ts",

--- a/packages/connect-node/.npmignore
+++ b/packages/connect-node/.npmignore
@@ -1,0 +1,4 @@
+/src
+/*.json
+/dist/*/**/*.spec.js
+/dist/*/**/*.spec.d.ts

--- a/packages/connect-node/jasmine.json
+++ b/packages/connect-node/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "dist/esm",
+  "spec_files": ["**/*.spec.js"],
+  "helpers": [],
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "random": true
+  }
+}

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "jasmine": "jasmine --config=jasmine.json"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",
@@ -30,6 +31,10 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/jasmine": "^4.3.1",
+    "jasmine": "^4.6.0"
   },
   "files": [
     "dist/**"

--- a/packages/connect-node/src/node-universal-header.spec.ts
+++ b/packages/connect-node/src/node-universal-header.spec.ts
@@ -1,0 +1,24 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { nodeHeaderToWebHeader } from "./node-universal-header.js";
+
+describe("nodeHeaderToWebHeader", function () {
+  it("should accept empty node header", function () {
+    const h = nodeHeaderToWebHeader({});
+    let numHeaders = 0;
+    h.forEach(() => numHeaders++);
+    expect(numHeaders).toBe(0);
+  });
+});

--- a/packages/connect-node/tsconfig.json
+++ b/packages/connect-node/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "files": ["src/index.ts"],
+  "include": ["src/**/*.spec.ts"],
   "extends": "../../tsconfig.base.json"
 }

--- a/packages/connect-web-test/package.json
+++ b/packages/connect-web-test/package.json
@@ -4,11 +4,11 @@
   "scripts": {
     "clean": "rm -rf ./dist/esm/*",
     "generate": "buf generate",
-    "build": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
-    "jasmine": "../../node_modules/.bin/jasmine --config=jasmine.json",
-    "karma": "../../node_modules/.bin/karma start karma.conf.cjs",
-    "karma-serve": "../../node_modules/.bin/karma start karma.serve.conf.cjs",
-    "karma-browserstack": "../../node_modules/.bin/karma start karma.browserstack.conf.cjs"
+    "build": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
+    "jasmine": "jasmine --config=jasmine.json",
+    "karma": "karma start karma.conf.cjs",
+    "karma-serve": "karma start karma.serve.conf.cjs",
+    "karma-browserstack": "karma start karma.browserstack.conf.cjs"
   },
   "type": "module",
   "types": "./dist/types/index.d.ts",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -13,9 +13,9 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "generate": "buf generate src/protocol-grpc/proto",
     "build": "npm run build:cjs && npm run build:esm+types",
-    "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
-    "jasmine": "../../node_modules/.bin/jasmine --config=jasmine.json"
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "jasmine": "jasmine --config=jasmine.json"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/protoc-gen-connect-es/package.json
+++ b/packages/protoc-gen-connect-es/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/cjs/*",
-    "build": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs"
+    "build": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs"
   },
   "preferUnplugged": true,
   "dependencies": {

--- a/packages/protoc-gen-connect-web/package.json
+++ b/packages/protoc-gen-connect-web/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/cjs/*",
-    "build": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs"
+    "build": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs"
   },
   "preferUnplugged": true,
   "dependencies": {


### PR DESCRIPTION
We are already extensively testing the @bufbuild/connect-node package from a separate package, but we want to add coverage for some unexported types.

This PR enables tests inside the package, and adds a simple first test.