### PR TITLE
Avoid the AbortController constructor during init

### DIFF
--- a/packages/connect/src/protocol/universal-handler.spec.ts
+++ b/packages/connect/src/protocol/universal-handler.spec.ts
@@ -35,7 +35,7 @@ describe("validateUniversalHandlerOptions()", function () {
       jsonOptions: undefined,
       binaryOptions: undefined,
       maxDeadlineDurationMs: Number.MAX_SAFE_INTEGER,
-      shutdownSignal: new AbortController().signal,
+      shutdownSignal: undefined,
       requireConnectProtocolHeader: false,
     });
   });

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -85,7 +85,7 @@ export interface UniversalHandlerOptions {
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
   maxDeadlineDurationMs: number; // TODO TCN-785
-  shutdownSignal: AbortSignal; // TODO TCN-919
+  shutdownSignal?: AbortSignal; // TODO TCN-919
 
   /**
    * Require requests using the Connect protocol to include the header
@@ -139,8 +139,6 @@ export interface UniversalHandler extends UniversalHandlerFn {
   supportedContentType: ContentTypeMatcher;
 }
 
-const neverSignal = new AbortController().signal;
-
 /**
  * Asserts that the options are within sane limits, and returns default values
  * where no value is provided.
@@ -156,7 +154,6 @@ export function validateUniversalHandlerOptions(
     : [];
   const requireConnectProtocolHeader =
     opt.requireConnectProtocolHeader ?? false;
-  const shutdownSignal = opt.shutdownSignal ?? neverSignal;
   const maxDeadlineDurationMs =
     opt.maxDeadlineDurationMs ?? Number.MAX_SAFE_INTEGER;
   return {
@@ -169,7 +166,7 @@ export function validateUniversalHandlerOptions(
     jsonOptions: opt.jsonOptions,
     binaryOptions: opt.binaryOptions,
     maxDeadlineDurationMs,
-    shutdownSignal,
+    shutdownSignal: opt.shutdownSignal,
     requireConnectProtocolHeader,
   };
 }


### PR DESCRIPTION
Cloudflare limits where AbortController can be instantiated, see https://github.com/bufbuild/connect-es/issues/550. We can safely remove our singleton. 

There are other calls to the constructor in clients, but from what I can see they all happen when a request is made, so it should be possible to create a transport and a client during init, and make a request while handling a request.
