### PR TITLE
Switch code size benchmark to use a JS brotli implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,6 @@ updatelocalhostcert:
 
 .PHONY: checkdiff
 checkdiff:
-	@# Used in CI to verify that `make` does not produce a diff, but ignore changes in benchmarks
-	git checkout packages/connect-web-bench/README.md
+	@# Used in CI to verify that `make` does not produce a diff
 	test -z "$$(git status --porcelain | tee /dev/stderr)"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,6 +2051,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browserstack": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.3.tgz",
@@ -5596,6 +5604,7 @@
         "@bufbuild/connect-web": "0.8.4",
         "@bufbuild/protobuf": "^1.0.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
+        "brotli": "^1.3.3",
         "esbuild": "^0.16.12",
         "google-protobuf": "^3.21.0",
         "grpc-web": "^1.4.2"

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 106,974 b | 46,906 b | 12,517 b |
-| grpc-web       | 414,906 b    | 301,127 b    | 53,226 b |
+| connect        | 106,974 b | 46,906 b | 12,546 b |
+| grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -10,6 +10,7 @@
     "@bufbuild/connect-web": "0.8.4",
     "@bufbuild/protobuf": "^1.0.0",
     "@bufbuild/protoc-gen-es": "^1.0.0",
+    "brotli": "^1.3.3",
     "esbuild": "^0.16.12",
     "google-protobuf": "^3.21.0",
     "grpc-web": "^1.4.2"

--- a/packages/connect-web-bench/report.mjs
+++ b/packages/connect-web-bench/report.mjs
@@ -1,5 +1,5 @@
-import { buildSync } from "esbuild";
-import { brotliCompressSync } from "zlib";
+import {buildSync} from "esbuild";
+import {compress} from "brotli";
 
 const connect = gather("src/entry-connect.ts");
 const grpcweb = gather("src/entry-grpcweb.ts");
@@ -45,10 +45,6 @@ function build(entryPoint, minify, format) {
     throw new Error();
   }
   return result.outputFiles[0].contents;
-}
-
-function compress(buf) {
-  return brotliCompressSync(buf);
 }
 
 function formatSize(bytes) {


### PR DESCRIPTION
This switches the code size benchmark to use the [brotli npm package](https://www.npmjs.com/package/brotli) (an Emscripten port of the [original C++ implementation](https://github.com/google/brotli)) instead of the Node.js zlib module.

We have seen slight variance of a couple of bytes between runs with the zlib module, and the JS implementation should produce stable numbers. This allows us to enable diffchecks on the results, so that CI can ensure the report is always current.