### PR TITLE
Mark private exports @private

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 107,215 b | 46,955 b | 12,542 b |
+| connect        | 107,215 b | 46,955 b | 12,525 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect/src/protocol-connect/code-string.ts
+++ b/packages/connect/src/protocol-connect/code-string.ts
@@ -16,6 +16,8 @@ import { Code } from "../code.js";
 
 /**
  * codeToString returns the string representation of a Code.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function codeToString(value: Code): string {
   const name = Code[value] as string | undefined;
@@ -35,6 +37,8 @@ let stringToCode: Record<string, Code> | undefined;
  * For example, the string "permission_denied" parses into Code.PermissionDenied.
  *
  * If the given string cannot be parsed, the function returns undefined.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function codeFromString(value: string): Code | undefined {
   if (!stringToCode) {

--- a/packages/connect/src/protocol-connect/content-type.ts
+++ b/packages/connect/src/protocol-connect/content-type.ts
@@ -14,18 +14,24 @@
 
 /**
  * Regular Expression that matches any valid Connect Content-Type header value.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const contentTypeRegExp =
   /^application\/(connect\+)?(?:(json)(?:; ?charset=utf-?8)?|(proto))$/i;
 
 /**
  * Regular Expression that matches a Connect unary Content-Type header value.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const contentTypeUnaryRegExp =
   /^application\/(?:json(?:; ?charset=utf-?8)?|proto)$/i;
 
 /**
  * Regular Expression that matches a Connect streaming Content-Type header value.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const contentTypeStreamRegExp =
   /^application\/connect\+?(?:json(?:; ?charset=utf-?8)?|proto)$/i;
@@ -37,6 +43,8 @@ export const contentTypeStreamJson = "application/connect+json";
 
 /**
  * Parse a Connect Content-Type header.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function parseContentType(
   contentType: string | null

--- a/packages/connect/src/protocol-connect/end-stream.ts
+++ b/packages/connect/src/protocol-connect/end-stream.ts
@@ -26,11 +26,15 @@ import type { Serialization } from "../protocol";
 /**
  * endStreamFlag indicates that the data in a EnvelopedMessage
  * is a EndStreamResponse of the Connect protocol.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const endStreamFlag = 0b00000010;
 
 /**
  * Represents the EndStreamResponse of the Connect protocol.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface EndStreamResponse {
   metadata: Headers;
@@ -40,6 +44,8 @@ export interface EndStreamResponse {
 /**
  * Parse an EndStreamResponse of the Connect protocol.
  * Throws a ConnectError on malformed input.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function endStreamFromJson(
   data: Uint8Array | string
@@ -97,6 +103,8 @@ export function endStreamFromJson(
  * google.protobuf.Any.
  *
  * See https://connect.build/docs/protocol#error-end-stream
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function endStreamToJson(
   metadata: Headers,
@@ -123,6 +131,8 @@ export function endStreamToJson(
 
 /**
  * Create a Serialization object that serializes a Connect EndStreamResponse.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createEndStreamSerialization(
   options: Partial<JsonWriteOptions> | undefined

--- a/packages/connect/src/protocol-connect/error-json.ts
+++ b/packages/connect/src/protocol-connect/error-json.ts
@@ -26,6 +26,8 @@ import { codeFromString, codeToString } from "./code-string.js";
 /**
  * Parse a Connect error from a JSON value.
  * Will return a ConnectError, and throw the provided fallback if parsing failed.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function errorFromJson(
   jsonValue: JsonValue,
@@ -84,6 +86,8 @@ export function errorFromJson(
 /**
  * Parse a Connect error from a serialized JSON value.
  * Will return a ConnectError, and throw the provided fallback if parsing failed.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function errorFromJsonBytes(
   bytes: Uint8Array,
@@ -108,6 +112,8 @@ export function errorFromJsonBytes(
  * is silently disregarded.
  *
  * See https://connect.build/docs/protocol#error-end-stream
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function errorToJson(
   error: ConnectError,
@@ -155,6 +161,8 @@ export function errorToJson(
 /**
  * Serialize the given error to JSON. This calls errorToJson(), but stringifies
  * the result, and converts it into a UInt8Array.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function errorToJsonBytes(
   error: ConnectError,

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -21,12 +21,9 @@ import {
   StringValue,
 } from "@bufbuild/protobuf";
 import { createHandlerFactory } from "./handler-factory.js";
-import {
-  createMethodImplSpec,
-  HandlerContext,
-  MethodImpl,
-} from "../implementation.js";
+import type { HandlerContext, MethodImpl } from "../implementation.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
+import { createMethodImplSpec } from "../implementation.js";
 import { errorFromJsonBytes } from "./error-json.js";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";

--- a/packages/connect/src/protocol-connect/headers.ts
+++ b/packages/connect/src/protocol-connect/headers.ts
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @private Internal code, does not follow semantic versioning.
+ */
 export const headerContentType = "Content-Type";
 export const headerUnaryContentLength = "Content-Length";
 export const headerUnaryEncoding = "Content-Encoding";

--- a/packages/connect/src/protocol-connect/http-status.ts
+++ b/packages/connect/src/protocol-connect/http-status.ts
@@ -17,6 +17,8 @@ import { Code } from "../code.js";
 /**
  * Determine the Connect error code for the given HTTP status code.
  * See https://connect.build/docs/protocol#error-codes
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function codeFromHttpStatus(httpStatus: number): Code {
   switch (httpStatus) {
@@ -56,6 +58,8 @@ export function codeFromHttpStatus(httpStatus: number): Code {
 /**
  * Returns a HTTP status code for the given Connect code.
  * See https://connect.build/docs/protocol#error-codes
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function codeToHttpStatus(code: Code): number {
   switch (code) {

--- a/packages/connect/src/protocol-connect/index.ts
+++ b/packages/connect/src/protocol-connect/index.ts
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export { createHandlerFactory } from "./handler-factory.js";
+export { createTransport } from "./transport.js";
+
+// All exports below are private — internal code that does not follow semantic
+// versioning.
+// We will try hard to avoid breaking changes, but if you depend on the
+// following exports, we recommend that you do so with an exact version
+// constraint (no ~ or ^).
+
 export { codeFromHttpStatus, codeToHttpStatus } from "./http-status.js";
 export {
   requestHeader,
@@ -50,5 +59,3 @@ export * from "./headers.js";
 export { protocolVersion } from "./version.js";
 export { codeFromString } from "./code-string.js";
 export { codeToString } from "./code-string.js";
-export { createHandlerFactory } from "./handler-factory.js";
-export { createTransport } from "./transport.js";

--- a/packages/connect/src/protocol-connect/parse-timeout.ts
+++ b/packages/connect/src/protocol-connect/parse-timeout.ts
@@ -17,6 +17,8 @@ import { ConnectError } from "../connect-error.js";
 
 /**
  * Parse a Connect Timeout (Deadline) header.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function parseTimeout(
   value: string | null

--- a/packages/connect/src/protocol-connect/request-header.ts
+++ b/packages/connect/src/protocol-connect/request-header.ts
@@ -33,6 +33,8 @@ import {
 
 /**
  * Creates headers for a Connect request.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeader(
   methodKind: MethodKind,
@@ -65,6 +67,8 @@ export function requestHeader(
  * It is up to the caller to decide whether to apply compression - and remove
  * the header if compression is not used, for example because the payload is
  * too small to make compression effective.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeaderWithCompression(
   methodKind: MethodKind,

--- a/packages/connect/src/protocol-connect/trailer-mux.ts
+++ b/packages/connect/src/protocol-connect/trailer-mux.ts
@@ -18,6 +18,8 @@
  *
  * This function demuxes headers and trailers into two separate Headers
  * objects.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function trailerDemux(
   header: Headers
@@ -39,6 +41,8 @@ export function trailerDemux(
  * fields, prefixed with "trailer-".
  *
  * This function muxes a header and a trailer into a single Headers object.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function trailerMux(header: Headers, trailer: Headers): Headers {
   const h = new Headers(header);

--- a/packages/connect/src/protocol-connect/validate-response.ts
+++ b/packages/connect/src/protocol-connect/validate-response.ts
@@ -28,6 +28,8 @@ import { headerUnaryEncoding, headerStreamEncoding } from "./headers.js";
  * application/json, this returns an error derived from the HTTP
  * status instead of throwing it, giving an implementation a chance
  * to parse a Connect error from the wire.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponse(
   methodKind: MethodKind,
@@ -72,6 +74,8 @@ export function validateResponse(
  * Validates response status and header for the Connect protocol.
  * This function is identical to validateResponse(), but also verifies
  * that a given encoding header is acceptable.
+ *
+ * @private
  */
 export function validateResponseWithCompression(
   methodKind: MethodKind,

--- a/packages/connect/src/protocol-connect/version.ts
+++ b/packages/connect/src/protocol-connect/version.ts
@@ -27,7 +27,7 @@ export const protocolVersion = "1";
  * Requires the Connect-Protocol-Version header to be present with the expected
  * value. Raises a ConnectError with Code.InvalidArgument otherwise.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requireProtocolVersion(requestHeader: Headers) {
   const v = requestHeader.get(headerProtocolVersion);

--- a/packages/connect/src/protocol-connect/version.ts
+++ b/packages/connect/src/protocol-connect/version.ts
@@ -18,12 +18,16 @@ import { Code } from "../code.js";
 
 /**
  * The only know value for the header Connect-Protocol-Version.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const protocolVersion = "1";
 
 /**
  * Requires the Connect-Protocol-Version header to be present with the expected
  * value. Raises a ConnectError with Code.InvalidArgument otherwise.
+ *
+ * @private
  */
 export function requireProtocolVersion(requestHeader: Headers) {
   const v = requestHeader.get(headerProtocolVersion);

--- a/packages/connect/src/protocol-grpc-web/content-type.ts
+++ b/packages/connect/src/protocol-grpc-web/content-type.ts
@@ -16,6 +16,8 @@
  * Regular Expression that matches any valid gRPC-web Content-Type header value.
  * Note that this includes application/grpc-web-text with the additional base64
  * encoding.
+ *
+ * @private
  */
 export const contentTypeRegExp =
   /^application\/grpc-web(-text)?(?:\+(?:(json)(?:; ?charset=utf-?8)?|proto))?$/i;
@@ -25,6 +27,8 @@ export const contentTypeJson = "application/grpc-web+json";
 
 /**
  * Parse a gRPC-web Content-Type header value.
+ *
+ * @private
  */
 export function parseContentType(
   contentType: string | null

--- a/packages/connect/src/protocol-grpc-web/content-type.ts
+++ b/packages/connect/src/protocol-grpc-web/content-type.ts
@@ -17,7 +17,7 @@
  * Note that this includes application/grpc-web-text with the additional base64
  * encoding.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export const contentTypeRegExp =
   /^application\/grpc-web(-text)?(?:\+(?:(json)(?:; ?charset=utf-?8)?|proto))?$/i;
@@ -28,7 +28,7 @@ export const contentTypeJson = "application/grpc-web+json";
 /**
  * Parse a gRPC-web Content-Type header value.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function parseContentType(
   contentType: string | null

--- a/packages/connect/src/protocol-grpc-web/headers.ts
+++ b/packages/connect/src/protocol-grpc-web/headers.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export {
   headerContentType,
@@ -28,7 +28,7 @@ export {
 /**
  * gRPC-web does not use the standard header User-Agent.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export const headerXUserAgent = "X-User-Agent";
 
@@ -39,6 +39,6 @@ export const headerXUserAgent = "X-User-Agent";
  * requests. For example the proxy by improbable:
  * https://github.com/improbable-eng/grpc-web/blob/53aaf4cdc0fede7103c1b06f0cfc560c003a5c41/go/grpcweb/wrapper.go#L231
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export const headerXGrpcWeb = "X-Grpc-Web";

--- a/packages/connect/src/protocol-grpc-web/headers.ts
+++ b/packages/connect/src/protocol-grpc-web/headers.ts
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @private
+ */
 export {
   headerContentType,
   headerEncoding,
@@ -24,6 +27,8 @@ export {
 
 /**
  * gRPC-web does not use the standard header User-Agent.
+ *
+ * @private
  */
 export const headerXUserAgent = "X-User-Agent";
 
@@ -33,5 +38,7 @@ export const headerXUserAgent = "X-User-Agent";
  * Some servers may rely on the header to identify gRPC-web
  * requests. For example the proxy by improbable:
  * https://github.com/improbable-eng/grpc-web/blob/53aaf4cdc0fede7103c1b06f0cfc560c003a5c41/go/grpcweb/wrapper.go#L231
+ *
+ * @private
  */
 export const headerXGrpcWeb = "X-Grpc-Web";

--- a/packages/connect/src/protocol-grpc-web/index.ts
+++ b/packages/connect/src/protocol-grpc-web/index.ts
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export { createHandlerFactory } from "./handler-factory.js";
+export { createTransport } from "./transport.js";
+
+// All exports below are private — internal code that does not follow semantic
+// versioning.
+// We will try hard to avoid breaking changes, but if you depend on the
+// following exports, we recommend that you do so with an exact version
+// constraint (no ~ or ^).
+
 export {
   requestHeader,
   requestHeaderWithCompression,
@@ -39,5 +48,3 @@ export {
   grpcStatusOk,
 } from "../protocol-grpc/index.js";
 export * from "./headers.js";
-export { createHandlerFactory } from "./handler-factory.js";
-export { createTransport } from "./transport.js";

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -25,6 +25,8 @@ import { contentTypeJson, contentTypeProto } from "./content-type.js";
 
 /**
  * Creates headers for a gRPC-web request.
+ *
+ * @private
  */
 export function requestHeader(
   useBinaryFormat: boolean,
@@ -51,6 +53,8 @@ export function requestHeader(
 
 /**
  * Creates headers for a gRPC-web request with compression.
+ *
+ * @private
  */
 export function requestHeaderWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -26,7 +26,7 @@ import { contentTypeJson, contentTypeProto } from "./content-type.js";
 /**
  * Creates headers for a gRPC-web request.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeader(
   useBinaryFormat: boolean,
@@ -54,7 +54,7 @@ export function requestHeader(
 /**
  * Creates headers for a gRPC-web request with compression.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeaderWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc-web/trailer.ts
+++ b/packages/connect/src/protocol-grpc-web/trailer.ts
@@ -18,14 +18,14 @@ import type { Serialization } from "../protocol";
  * trailerFlag indicates that the data in a EnvelopedMessage
  * is a set of trailers of the gRPC-web protocol.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export const trailerFlag = 0b10000000;
 
 /**
  * Parse a gRPC-web trailer, a set of header fields separated by CRLF.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function trailerParse(data: Uint8Array): Headers {
   const headers = new Headers();
@@ -47,7 +47,7 @@ export function trailerParse(data: Uint8Array): Headers {
 /**
  * Serialize a Headers object as a gRPC-web trailer.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function trailerSerialize(trailer: Headers): Uint8Array {
   const lines: string[] = [];
@@ -61,7 +61,7 @@ export function trailerSerialize(trailer: Headers): Uint8Array {
  * Create a Serialization object that serializes a gRPC-web trailer, a Headers
  * object that is serialized as a set of header fields, separated by CRLF.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createTrailerSerialization(): Serialization<Headers> {
   return {

--- a/packages/connect/src/protocol-grpc-web/trailer.ts
+++ b/packages/connect/src/protocol-grpc-web/trailer.ts
@@ -17,11 +17,15 @@ import type { Serialization } from "../protocol";
 /**
  * trailerFlag indicates that the data in a EnvelopedMessage
  * is a set of trailers of the gRPC-web protocol.
+ *
+ * @private
  */
 export const trailerFlag = 0b10000000;
 
 /**
  * Parse a gRPC-web trailer, a set of header fields separated by CRLF.
+ *
+ * @private
  */
 export function trailerParse(data: Uint8Array): Headers {
   const headers = new Headers();
@@ -42,6 +46,8 @@ export function trailerParse(data: Uint8Array): Headers {
 
 /**
  * Serialize a Headers object as a gRPC-web trailer.
+ *
+ * @private
  */
 export function trailerSerialize(trailer: Headers): Uint8Array {
   const lines: string[] = [];
@@ -54,6 +60,8 @@ export function trailerSerialize(trailer: Headers): Uint8Array {
 /**
  * Create a Serialization object that serializes a gRPC-web trailer, a Headers
  * object that is serialized as a set of header fields, separated by CRLF.
+ *
+ * @private
  */
 export function createTrailerSerialization(): Serialization<Headers> {
   return {

--- a/packages/connect/src/protocol-grpc-web/validate-response.ts
+++ b/packages/connect/src/protocol-grpc-web/validate-response.ts
@@ -36,7 +36,7 @@ import {
  * in the response header. In this case, clients can not expect a
  * trailer.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponse(
   useBinaryFormat: boolean,
@@ -80,7 +80,7 @@ export function validateResponse(
  * indicating whether a gRPC status was found in the response header
  * (in this case, clients can not expect a trailer).
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponseWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc-web/validate-response.ts
+++ b/packages/connect/src/protocol-grpc-web/validate-response.ts
@@ -35,6 +35,8 @@ import {
  * Returns an object that indicates whether a gRPC status was found
  * in the response header. In this case, clients can not expect a
  * trailer.
+ *
+ * @private
  */
 export function validateResponse(
   useBinaryFormat: boolean,
@@ -77,6 +79,8 @@ export function validateResponse(
  * Returns an object with the response compression, and a boolean
  * indicating whether a gRPC status was found in the response header
  * (in this case, clients can not expect a trailer).
+ *
+ * @private
  */
 export function validateResponseWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc/content-type.ts
+++ b/packages/connect/src/protocol-grpc/content-type.ts
@@ -14,6 +14,8 @@
 
 /**
  * Regular Expression that matches any valid gRPC Content-Type header value.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const contentTypeRegExp =
   /^application\/grpc(?:\+(?:(json)(?:; ?charset=utf-?8)?|proto))?$/i;
@@ -23,6 +25,8 @@ export const contentTypeJson = "application/grpc+json";
 
 /**
  * Parse a gRPC Content-Type header.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function parseContentType(
   contentType: string | null

--- a/packages/connect/src/protocol-grpc/headers.ts
+++ b/packages/connect/src/protocol-grpc/headers.ts
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @private Internal code, does not follow semantic versioning.
+ */
 export const headerContentType = "Content-Type";
 export const headerEncoding = "Grpc-Encoding";
 export const headerAcceptEncoding = "Grpc-Accept-Encoding";

--- a/packages/connect/src/protocol-grpc/http-status.ts
+++ b/packages/connect/src/protocol-grpc/http-status.ts
@@ -17,6 +17,8 @@ import { Code } from "../code.js";
 /**
  * Determine the gRPC-web error code for the given HTTP status code.
  * See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function codeFromHttpStatus(httpStatus: number): Code | null {
   // TODO we should treat HTTP 200 as unknown if the field grpc-status is not present

--- a/packages/connect/src/protocol-grpc/index.ts
+++ b/packages/connect/src/protocol-grpc/index.ts
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export { createHandlerFactory } from "./handler-factory.js";
+export { createTransport } from "./transport.js";
+
+// All exports below are private — internal code that does not follow semantic
+// versioning.
+// We will try hard to avoid breaking changes, but if you depend on the
+// following exports, we recommend that you do so with an exact version
+// constraint (no ~ or ^).
+
 export { codeFromHttpStatus } from "./http-status.js";
 export {
   requestHeader,
@@ -35,5 +44,3 @@ export {
 } from "./validate-response.js";
 export { validateTrailer } from "./validate-trailer.js";
 export * from "./headers.js";
-export { createHandlerFactory } from "./handler-factory.js";
-export { createTransport } from "./transport.js";

--- a/packages/connect/src/protocol-grpc/parse-timeout.ts
+++ b/packages/connect/src/protocol-grpc/parse-timeout.ts
@@ -17,6 +17,8 @@ import { ConnectError } from "../connect-error.js";
 
 /**
  * Parse a gRPC Timeout (Deadline) header.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function parseTimeout(
   value: string | null

--- a/packages/connect/src/protocol-grpc/request-header.ts
+++ b/packages/connect/src/protocol-grpc/request-header.ts
@@ -24,6 +24,8 @@ import { contentTypeJson, contentTypeProto } from "./content-type.js";
 
 /**
  * Creates headers for a gRPC request.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeader(
   useBinaryFormat: boolean,
@@ -50,6 +52,8 @@ export function requestHeader(
 
 /**
  * Creates headers for a gRPC request with compression.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeaderWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc/trailer-status.ts
+++ b/packages/connect/src/protocol-grpc/trailer-status.ts
@@ -38,7 +38,7 @@ export const grpcStatusOk = "0";
  * will also set the field "grpc-status-details-bin" with an encoded
  * google.rpc.Status message including the error details.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function setTrailerStatus(
   target: Headers,
@@ -75,7 +75,7 @@ export function setTrailerStatus(
  * the fields "grpc-status" and "grpc-message" are used.
  * Returns an error only if the gRPC status code is > 0.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function findTrailerError(
   headerOrTrailer: Headers

--- a/packages/connect/src/protocol-grpc/trailer-status.ts
+++ b/packages/connect/src/protocol-grpc/trailer-status.ts
@@ -26,6 +26,8 @@ import {
 /**
  * The value of the Grpc-Status header or trailer in case of success.
  * Used by the gRPC and gRPC-web protocols.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const grpcStatusOk = "0";
 
@@ -35,6 +37,8 @@ export const grpcStatusOk = "0";
  * If an error is given and contains error details, the function
  * will also set the field "grpc-status-details-bin" with an encoded
  * google.rpc.Status message including the error details.
+ *
+ * @private
  */
 export function setTrailerStatus(
   target: Headers,
@@ -70,6 +74,8 @@ export function setTrailerStatus(
  * The field "grpc-status-details-bin" is inspected, and if not present,
  * the fields "grpc-status" and "grpc-message" are used.
  * Returns an error only if the gRPC status code is > 0.
+ *
+ * @private
  */
 export function findTrailerError(
   headerOrTrailer: Headers

--- a/packages/connect/src/protocol-grpc/validate-response.ts
+++ b/packages/connect/src/protocol-grpc/validate-response.ts
@@ -73,7 +73,7 @@ export function validateResponse(
  * indicating whether a gRPC status was found in the response header
  * (in this case, clients can not expect a trailer).
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponseWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc/validate-response.ts
+++ b/packages/connect/src/protocol-grpc/validate-response.ts
@@ -34,6 +34,8 @@ import {
  * Returns an object that indicates whether a gRPC status was found
  * in the response header. In this case, clients can not expect a
  * trailer.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponse(
   useBinaryFormat: boolean,
@@ -70,6 +72,8 @@ export function validateResponse(
  * Returns an object with the response compression, and a boolean
  * indicating whether a gRPC status was found in the response header
  * (in this case, clients can not expect a trailer).
+ *
+ * @private
  */
 export function validateResponseWithCompression(
   useBinaryFormat: boolean,

--- a/packages/connect/src/protocol-grpc/validate-trailer.ts
+++ b/packages/connect/src/protocol-grpc/validate-trailer.ts
@@ -17,6 +17,8 @@ import { findTrailerError } from "./trailer-status.js";
 /**
  * Validates a trailer for the gRPC and the gRPC-web protocol.
  * Throws a ConnectError if the trailer contains an error status.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateTrailer(trailer: Headers): void {
   const err = findTrailerError(trailer);

--- a/packages/connect/src/protocol/async-iterable.ts
+++ b/packages/connect/src/protocol/async-iterable.ts
@@ -50,6 +50,8 @@ import { assertReadMaxBytes } from "./limit-io.js";
  * ```
  *
  * Transformation functions can be passed to pipe() and pipeTo().
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export type AsyncIterableTransform<I, O = I> = (
   data: AsyncIterable<I>
@@ -60,6 +62,8 @@ export type AsyncIterableTransform<I, O = I> = (
  * to the end, optionally returning a cumulative value.
  *
  * Sinks are the used with pipeTo().
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export type AsyncIterableSink<T, R = void> = (
   iterable: AsyncIterable<T>
@@ -68,7 +72,7 @@ export type AsyncIterableSink<T, R = void> = (
 /**
  * Options for pipe() and pipeTo().
  *
- *
+ * @private Internal code, does not follow semantic versioning.
  */
 interface PipeOptions {
   /**
@@ -126,6 +130,8 @@ interface PipeOptions {
  *
  * It is either a deserialized message M, or a deserialized end-of-stream
  * message E, typically distinguished by a flag on an enveloped message.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 type ParsedEnvelopedMessage<M, E> =
   | { end: false; value: M }
@@ -133,6 +139,8 @@ type ParsedEnvelopedMessage<M, E> =
 
 /**
  * Takes an asynchronous iterable as a source, and passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2>(
   iterable: AsyncIterable<T1>,
@@ -142,6 +150,8 @@ export function pipeTo<T1, T2>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3>(
   iterable: AsyncIterable<T1>,
@@ -152,6 +162,8 @@ export function pipeTo<T1, T2, T3>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4>(
   iterable: AsyncIterable<T1>,
@@ -163,6 +175,8 @@ export function pipeTo<T1, T2, T3, T4>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5>(
   iterable: AsyncIterable<T1>,
@@ -175,6 +189,8 @@ export function pipeTo<T1, T2, T3, T4, T5>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6>(
   iterable: AsyncIterable<T1>,
@@ -188,6 +204,8 @@ export function pipeTo<T1, T2, T3, T4, T5, T6>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7>(
   iterable: AsyncIterable<T1>,
@@ -202,6 +220,8 @@ export function pipeTo<T1, T2, T3, T4, T5, T6, T7>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8>(
   iterable: AsyncIterable<T1>,
@@ -217,6 +237,8 @@ export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
   iterable: AsyncIterable<T1>,
@@ -233,6 +255,8 @@ export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
   iterable: AsyncIterable<T1>,
@@ -251,40 +275,44 @@ export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-  iterable: AsyncIterable<T1>,
-  transform1: AsyncIterableTransform<T1, T2>,
-  transform2: AsyncIterableTransform<T2, T3>,
-  transform3: AsyncIterableTransform<T3, T4>,
-  transform4: AsyncIterableTransform<T4, T5>,
-  transform5: AsyncIterableTransform<T5, T6>,
-  transform6: AsyncIterableTransform<T6, T7>,
-  transform7: AsyncIterableTransform<T7, T8>,
-  transform8: AsyncIterableTransform<T8, T9>,
-  transform9: AsyncIterableTransform<T9, T10>,
-  sink: AsyncIterableSink<T10, T11>,
-  options?: PipeOptions
+    iterable: AsyncIterable<T1>,
+    transform1: AsyncIterableTransform<T1, T2>,
+    transform2: AsyncIterableTransform<T2, T3>,
+    transform3: AsyncIterableTransform<T3, T4>,
+    transform4: AsyncIterableTransform<T4, T5>,
+    transform5: AsyncIterableTransform<T5, T6>,
+    transform6: AsyncIterableTransform<T6, T7>,
+    transform7: AsyncIterableTransform<T7, T8>,
+    transform8: AsyncIterableTransform<T8, T9>,
+    transform9: AsyncIterableTransform<T9, T10>,
+    sink: AsyncIterableSink<T10, T11>,
+    options?: PipeOptions
 ): Promise<T11>;
 // prettier-ignore
 /**
  * Takes an asynchronous iterable as a source, applies transformations, and
  * passes it to a sink.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipeTo<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-  iterable: AsyncIterable<T1>,
-  transform1: AsyncIterableTransform<T1, T2>,
-  transform2: AsyncIterableTransform<T2, T3>,
-  transform3: AsyncIterableTransform<T3, T4>,
-  transform4: AsyncIterableTransform<T4, T5>,
-  transform5: AsyncIterableTransform<T5, T6>,
-  transform6: AsyncIterableTransform<T6, T7>,
-  transform7: AsyncIterableTransform<T7, T8>,
-  transform8: AsyncIterableTransform<T8, T9>,
-  transform9: AsyncIterableTransform<T9, T10>,
-  transform10: AsyncIterableTransform<T10, T11>,
-  sink: AsyncIterableSink<T11, T12>,
-  options?: PipeOptions
+    iterable: AsyncIterable<T1>,
+    transform1: AsyncIterableTransform<T1, T2>,
+    transform2: AsyncIterableTransform<T2, T3>,
+    transform3: AsyncIterableTransform<T3, T4>,
+    transform4: AsyncIterableTransform<T4, T5>,
+    transform5: AsyncIterableTransform<T5, T6>,
+    transform6: AsyncIterableTransform<T6, T7>,
+    transform7: AsyncIterableTransform<T7, T8>,
+    transform8: AsyncIterableTransform<T8, T9>,
+    transform9: AsyncIterableTransform<T9, T10>,
+    transform10: AsyncIterableTransform<T10, T11>,
+    sink: AsyncIterableSink<T11, T12>,
+    options?: PipeOptions
 ): Promise<T12>;
 export function pipeTo(
   source: AsyncIterable<unknown>,
@@ -328,6 +356,8 @@ function pickTransformsAndSink(
 
 /**
  * Creates an AsyncIterableSink that concatenates all elements from the input.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function sinkAll<T>(): AsyncIterableSink<T, T[]> {
   return async function (iterable: AsyncIterable<T>) {
@@ -350,6 +380,8 @@ export function sinkAll<T>(): AsyncIterableSink<T, T[]> {
  * and error is raised.
  * If the length hint is larger than readMaxBytes, an error is raised.
  * If the length hint is not a positive integer, it is ignored.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function sinkAllBytes(
   readMaxBytes: number,
@@ -362,6 +394,8 @@ export function sinkAllBytes(
 
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2>(
   iterable: AsyncIterable<T1>,
@@ -370,6 +404,8 @@ export function pipe<T1, T2>(
 ): AsyncIterable<T2>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3>(
   iterable: AsyncIterable<T1>,
@@ -379,6 +415,8 @@ export function pipe<T1, T2, T3>(
 ): AsyncIterable<T3>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4>(
   iterable: AsyncIterable<T1>,
@@ -389,6 +427,8 @@ export function pipe<T1, T2, T3, T4>(
 ): AsyncIterable<T4>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5>(
   iterable: AsyncIterable<T1>,
@@ -400,6 +440,8 @@ export function pipe<T1, T2, T3, T4, T5>(
 ): AsyncIterable<T5>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6>(
   iterable: AsyncIterable<T1>,
@@ -412,6 +454,8 @@ export function pipe<T1, T2, T3, T4, T5, T6>(
 ): AsyncIterable<T6>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7>(
   iterable: AsyncIterable<T1>,
@@ -425,6 +469,8 @@ export function pipe<T1, T2, T3, T4, T5, T6, T7>(
 ): AsyncIterable<T7>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7, T8>(
   iterable: AsyncIterable<T1>,
@@ -439,6 +485,8 @@ export function pipe<T1, T2, T3, T4, T5, T6, T7, T8>(
 ): AsyncIterable<T8>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
   iterable: AsyncIterable<T1>,
@@ -454,6 +502,8 @@ export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
 ): AsyncIterable<T9>;
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
   iterable: AsyncIterable<T1>,
@@ -471,39 +521,43 @@ export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 // prettier-ignore
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-  iterable: AsyncIterable<T1>,
-  transform1: AsyncIterableTransform<T1, T2>,
-  transform2: AsyncIterableTransform<T2, T3>,
-  transform3: AsyncIterableTransform<T3, T4>,
-  transform4: AsyncIterableTransform<T4, T5>,
-  transform5: AsyncIterableTransform<T5, T6>,
-  transform6: AsyncIterableTransform<T6, T7>,
-  transform7: AsyncIterableTransform<T7, T8>,
-  transform8: AsyncIterableTransform<T8, T9>,
-  transform9: AsyncIterableTransform<T9, T10>,
-  transform10: AsyncIterableTransform<T10, T11>,
-  options?: PipeOptions
+    iterable: AsyncIterable<T1>,
+    transform1: AsyncIterableTransform<T1, T2>,
+    transform2: AsyncIterableTransform<T2, T3>,
+    transform3: AsyncIterableTransform<T3, T4>,
+    transform4: AsyncIterableTransform<T4, T5>,
+    transform5: AsyncIterableTransform<T5, T6>,
+    transform6: AsyncIterableTransform<T6, T7>,
+    transform7: AsyncIterableTransform<T7, T8>,
+    transform8: AsyncIterableTransform<T8, T9>,
+    transform9: AsyncIterableTransform<T9, T10>,
+    transform10: AsyncIterableTransform<T10, T11>,
+    options?: PipeOptions
 ): AsyncIterable<T11>;
 // prettier-ignore
 /**
  * Apply one or more transformations to an asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function pipe<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-  iterable: AsyncIterable<T1>,
-  transform1: AsyncIterableTransform<T1, T2>,
-  transform2: AsyncIterableTransform<T2, T3>,
-  transform3: AsyncIterableTransform<T3, T4>,
-  transform4: AsyncIterableTransform<T4, T5>,
-  transform5: AsyncIterableTransform<T5, T6>,
-  transform6: AsyncIterableTransform<T6, T7>,
-  transform7: AsyncIterableTransform<T7, T8>,
-  transform8: AsyncIterableTransform<T8, T9>,
-  transform9: AsyncIterableTransform<T9, T10>,
-  transform10: AsyncIterableTransform<T10, T11>,
-  transform11: AsyncIterableTransform<T11, T12>,
-  options?: PipeOptions
+    iterable: AsyncIterable<T1>,
+    transform1: AsyncIterableTransform<T1, T2>,
+    transform2: AsyncIterableTransform<T2, T3>,
+    transform3: AsyncIterableTransform<T3, T4>,
+    transform4: AsyncIterableTransform<T4, T5>,
+    transform5: AsyncIterableTransform<T5, T6>,
+    transform6: AsyncIterableTransform<T6, T7>,
+    transform7: AsyncIterableTransform<T7, T8>,
+    transform8: AsyncIterableTransform<T8, T9>,
+    transform9: AsyncIterableTransform<T9, T10>,
+    transform10: AsyncIterableTransform<T10, T11>,
+    transform11: AsyncIterableTransform<T11, T12>,
+    options?: PipeOptions
 ): AsyncIterable<T12>;
 export async function* pipe<I, O>(
   source: AsyncIterable<I>,
@@ -552,6 +606,8 @@ function pickTransforms(
  * passes it to the given catchError function.
  *
  * The catchError function may return a final value.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformCatch<T>(
   catchError: TransformCatchErrorFn<T>
@@ -588,6 +644,8 @@ type TransformCatchErrorFn<C> =
  * Creates an AsyncIterableTransform that catches any error from the input, and
  * passes it to the given function. Unlike transformCatch(), the given function
  * is also called when no error is raised.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformCatchFinally<T>(
   catchFinally: TransformCatchFinallyFn<T>
@@ -626,6 +684,8 @@ type TransformCatchFinallyFn<C> =
  *
  * The element to append is provided by a function. If the function returns
  * undefined, no element is appended.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformAppend<T>(
   provide: TransformXpendProvide<T>
@@ -646,6 +706,8 @@ export function transformAppend<T>(
  *
  * The element to prepend is provided by a function. If the function returns
  * undefined, no element is appended.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformPrepend<T>(
   provide: TransformXpendProvide<T>
@@ -676,6 +738,8 @@ type TransformXpendProvide<T> = T extends undefined
  * and error is raised.
  * If the length hint is larger than readMaxBytes, an error is raised.
  * If the length hint is not a positive integer, it is ignored.
+ *
+ * @private
  */
 export function transformReadAllBytes(
   readMaxBytes: number,
@@ -689,6 +753,8 @@ export function transformReadAllBytes(
 /**
  * Creates an AsyncIterableTransform that takes partial protobuf messages of the
  * specified message type as input, and yields full instances.
+ *
+ * @private
  */
 export function transformNormalizeMessage<T extends Message<T>>(
   messageType: MessageType<T>
@@ -711,6 +777,8 @@ export function transformNormalizeMessage<T extends Message<T>>(
  * Note that this function has an override that lets the input stream
  * distinguish between regular messages, and end-of-stream messages, as used
  * by the RPP-web and Connect protocols.
+ *
+ * @private
  */
 export function transformSerializeEnvelope<T>(
   serialization: Serialization<T>
@@ -726,6 +794,8 @@ export function transformSerializeEnvelope<T>(
  * A source with { end: false, value: ... } is serialized using the given
  * serialization, and the resulting enveloped message does not have the given
  * endStreamFlag.
+ *
+ * @private
  */
 export function transformSerializeEnvelope<T, E>(
   serialization: Serialization<T>,
@@ -773,6 +843,8 @@ export function transformSerializeEnvelope<T, E>(
  * Note that this function has overrides that let the stream distinguish
  * between regular messages, and end-of-stream messages, as used by the
  * gRPP-web and Connect protocols.
+ *
+ * @private
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>
@@ -783,6 +855,8 @@ export function transformParseEnvelope<T>(
  *
  * Note that this override will look for the given endStreamFlag, and silently
  * ignore envelopes with this flag.
+ *
+ * @private
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>,
@@ -794,6 +868,8 @@ export function transformParseEnvelope<T>(
  *
  * Note that this override will look for the given endStreamFlag, and raise
  * and error if it is set.
+ *
+ * @private
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>,
@@ -810,6 +886,8 @@ export function transformParseEnvelope<T>(
  *
  * If the endStreamFlag is not set, the payload is parsed using the given
  * serialization, and an object with { end: false, value: ... } is returned.
+ *
+ * @private
  */
 export function transformParseEnvelope<T, E>(
   serialization: Serialization<T>,
@@ -860,6 +938,8 @@ export function transformParseEnvelope<T, E>(
 /**
  * Creates an AsyncIterableTransform that takes enveloped messages as a source,
  * and compresses them if they are larger than compressMinBytes.
+ *
+ * @private
  */
 export function transformCompressEnvelope(
   compression: Compression | null,
@@ -877,7 +957,9 @@ export function transformCompressEnvelope(
  * and decompresses them using the given compression.
  *
  * The iterable raises an error if the decompressed payload of an enveloped
- * message is larger than readMaxBytes,
+ * message is larger than readMaxBytes, or if no compression is provided.
+ *
+ * @private
  */
 export function transformDecompressEnvelope(
   compression: Compression | null,
@@ -893,6 +975,8 @@ export function transformDecompressEnvelope(
 /**
  * Create an AsyncIterableTransform that takes enveloped messages as a source,
  * and joins them into a stream of raw bytes.
+ *
+ * @private
  */
 export function transformJoinEnvelopes(): AsyncIterableTransform<
   EnvelopedMessage,
@@ -913,6 +997,8 @@ export function transformJoinEnvelopes(): AsyncIterableTransform<
  * - if the payload of an enveloped message is larger than readMaxBytes,
  * - if the stream ended before an enveloped message fully arrived,
  * - or if the stream ended with extraneous data.
+ *
+ * @private
  */
 export function transformSplitEnvelope(
   readMaxBytes: number
@@ -996,6 +1082,8 @@ export function transformSplitEnvelope(
  * - lengthHint is a positive integer, but larger than readMaxBytes
  * - lengthHint is a positive integer, and the source contains more or less bytes
  *   than promised
+ *
+ * @private
  */
 export async function readAllBytes(
   iterable: AsyncIterable<Uint8Array>,
@@ -1097,6 +1185,8 @@ type AbortState = "rethrown" | "completed" | "caught";
  *
  * Note that catching errors and yielding a value is problematic, and it should
  * be documented that this may leave the source in a dangling state.
+ *
+ * @private
  */
 export function makeIterableAbortable<T>(
   iterable: AsyncIterable<T>
@@ -1265,6 +1355,8 @@ export function createWritableIterable<T>(): WritableIterable<T> {
 
 /**
  * Create an asynchronous iterable from an array.
+ *
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function* createAsyncIterable<T>(items: T[]): AsyncIterable<T> {

--- a/packages/connect/src/protocol/async-iterable.ts
+++ b/packages/connect/src/protocol/async-iterable.ts
@@ -739,7 +739,7 @@ type TransformXpendProvide<T> = T extends undefined
  * If the length hint is larger than readMaxBytes, an error is raised.
  * If the length hint is not a positive integer, it is ignored.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformReadAllBytes(
   readMaxBytes: number,
@@ -754,7 +754,7 @@ export function transformReadAllBytes(
  * Creates an AsyncIterableTransform that takes partial protobuf messages of the
  * specified message type as input, and yields full instances.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformNormalizeMessage<T extends Message<T>>(
   messageType: MessageType<T>
@@ -778,7 +778,7 @@ export function transformNormalizeMessage<T extends Message<T>>(
  * distinguish between regular messages, and end-of-stream messages, as used
  * by the RPP-web and Connect protocols.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformSerializeEnvelope<T>(
   serialization: Serialization<T>
@@ -795,7 +795,7 @@ export function transformSerializeEnvelope<T>(
  * serialization, and the resulting enveloped message does not have the given
  * endStreamFlag.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformSerializeEnvelope<T, E>(
   serialization: Serialization<T>,
@@ -844,7 +844,7 @@ export function transformSerializeEnvelope<T, E>(
  * between regular messages, and end-of-stream messages, as used by the
  * gRPP-web and Connect protocols.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>
@@ -856,7 +856,7 @@ export function transformParseEnvelope<T>(
  * Note that this override will look for the given endStreamFlag, and silently
  * ignore envelopes with this flag.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>,
@@ -869,7 +869,7 @@ export function transformParseEnvelope<T>(
  * Note that this override will look for the given endStreamFlag, and raise
  * and error if it is set.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformParseEnvelope<T>(
   serialization: Serialization<T>,
@@ -887,7 +887,7 @@ export function transformParseEnvelope<T>(
  * If the endStreamFlag is not set, the payload is parsed using the given
  * serialization, and an object with { end: false, value: ... } is returned.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformParseEnvelope<T, E>(
   serialization: Serialization<T>,
@@ -939,7 +939,7 @@ export function transformParseEnvelope<T, E>(
  * Creates an AsyncIterableTransform that takes enveloped messages as a source,
  * and compresses them if they are larger than compressMinBytes.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformCompressEnvelope(
   compression: Compression | null,
@@ -959,7 +959,7 @@ export function transformCompressEnvelope(
  * The iterable raises an error if the decompressed payload of an enveloped
  * message is larger than readMaxBytes, or if no compression is provided.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformDecompressEnvelope(
   compression: Compression | null,
@@ -976,7 +976,7 @@ export function transformDecompressEnvelope(
  * Create an AsyncIterableTransform that takes enveloped messages as a source,
  * and joins them into a stream of raw bytes.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformJoinEnvelopes(): AsyncIterableTransform<
   EnvelopedMessage,
@@ -998,7 +998,7 @@ export function transformJoinEnvelopes(): AsyncIterableTransform<
  * - if the stream ended before an enveloped message fully arrived,
  * - or if the stream ended with extraneous data.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformSplitEnvelope(
   readMaxBytes: number
@@ -1083,7 +1083,7 @@ export function transformSplitEnvelope(
  * - lengthHint is a positive integer, and the source contains more or less bytes
  *   than promised
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export async function readAllBytes(
   iterable: AsyncIterable<Uint8Array>,
@@ -1186,7 +1186,7 @@ type AbortState = "rethrown" | "completed" | "caught";
  * Note that catching errors and yielding a value is problematic, and it should
  * be documented that this may leave the source in a dangling state.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 export function makeIterableAbortable<T>(
   iterable: AsyncIterable<T>
@@ -1356,7 +1356,7 @@ export function createWritableIterable<T>(): WritableIterable<T> {
 /**
  * Create an asynchronous iterable from an array.
  *
- * @private
+ * @private Internal code, does not follow semantic versioning.
  */
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function* createAsyncIterable<T>(items: T[]): AsyncIterable<T> {

--- a/packages/connect/src/protocol/compression.ts
+++ b/packages/connect/src/protocol/compression.ts
@@ -19,6 +19,8 @@ import { Code } from "../code.js";
  * compressedFlag indicates that the data in a EnvelopedMessage is
  * compressed. It has the same meaning in the gRPC-Web, gRPC-HTTP2,
  * and Connect protocols.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const compressedFlag = 0b00000001;
 
@@ -52,6 +54,8 @@ export interface Compression {
  * Returns the request and response compression to use. If the client requested
  * an encoding that is not available, the returned object contains an error that
  * must be used for the response.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function compressionNegotiate(
   available: Compression[],

--- a/packages/connect/src/protocol/content-type-matcher.ts
+++ b/packages/connect/src/protocol/content-type-matcher.ts
@@ -14,6 +14,8 @@
 
 /**
  * A function that returns true if a given mime type is supported.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface ContentTypeMatcher {
   (contentType: string | null): boolean;
@@ -25,6 +27,8 @@ const contentTypeMatcherCacheSize = 1024;
 /**
  * Create a function that returns true if the given mime type is supported.
  * A mime type is supported when one of the regular expressions match.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function contentTypeMatcher(
   ...supported: (RegExp | Pick<ContentTypeMatcher, "supported">)[]

--- a/packages/connect/src/protocol/envelope.ts
+++ b/packages/connect/src/protocol/envelope.ts
@@ -19,6 +19,8 @@ import { compressedFlag, Compression } from "./compression.js";
 /**
  * Represents an Enveloped-Message of the Connect protocol.
  * https://connect.build/docs/protocol#streaming-rpcs
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface EnvelopedMessage {
   /**
@@ -38,6 +40,8 @@ export interface EnvelopedMessage {
  *
  * Ideally, this would simply be a TransformStream, but ReadableStream.pipeThrough
  * does not have the necessary availability at this time.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createEnvelopeReadableStream(
   stream: ReadableStream<Uint8Array>
@@ -99,6 +103,8 @@ export function createEnvelopeReadableStream(
  * Compress an EnvelopedMessage.
  *
  * Raises Internal if an enveloped message is already compressed.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export async function envelopeCompress(
   envelope: EnvelopedMessage,
@@ -127,6 +133,8 @@ export async function envelopeCompress(
  * Relies on the provided Compression to raise ResourceExhausted if the
  * *decompressed* message size is larger than readMaxBytes. If the envelope is
  * not compressed, readMaxBytes is not honored.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export async function envelopeDecompress(
   envelope: EnvelopedMessage,
@@ -149,6 +157,8 @@ export async function envelopeDecompress(
 
 /**
  * Encode a single enveloped message.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function encodeEnvelope(flags: number, data: Uint8Array): Uint8Array {
   const bytes = new Uint8Array(data.length + 5);
@@ -161,6 +171,8 @@ export function encodeEnvelope(flags: number, data: Uint8Array): Uint8Array {
 
 /**
  * Encode a set of enveloped messages.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function encodeEnvelopes(...envelopes: EnvelopedMessage[]): Uint8Array {
   const len = envelopes.reduce(

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -13,6 +13,24 @@
 // limitations under the License.
 
 export { createMethodUrl } from "./create-method-url.js";
+export type {
+  UniversalClientFn,
+  UniversalClientRequest,
+  UniversalClientResponse,
+  UniversalHandlerFn,
+  UniversalServerRequest,
+  UniversalServerResponse,
+} from "./universal.js";
+export type { Compression } from "./compression.js";
+export type { UniversalHandler } from "./universal-handler.js";
+export { createUniversalHandlerClient } from "./universal-handler-client.js";
+
+// All exports below are private — internal code that does not follow semantic
+// versioning.
+// We will try hard to avoid breaking changes, but if you depend on the
+// following exports, we recommend that you do so with an exact version
+// constraint (no ~ or ^).
+
 export {
   createMethodSerializationLookup,
   createClientMethodSerializers,
@@ -32,7 +50,6 @@ export {
 } from "./envelope.js";
 export type { EnvelopedMessage } from "./envelope.js";
 export { compressedFlag, compressionNegotiate } from "./compression.js";
-export type { Compression } from "./compression.js";
 export {
   pipe,
   transformCatch,
@@ -74,23 +91,11 @@ export {
   uResponseMethodNotAllowed,
   uResponseVersionNotSupported,
 } from "./universal.js";
-export type {
-  UniversalClientFn,
-  UniversalClientRequest,
-  UniversalClientResponse,
-  UniversalHandlerFn,
-  UniversalServerRequest,
-  UniversalServerResponse,
-} from "./universal.js";
-export { createUniversalHandlerClient } from "./universal-handler-client.js";
 export {
   validateUniversalHandlerOptions,
   createUniversalServiceHandlers,
   createUniversalMethodHandler,
 } from "./universal-handler.js";
-export type {
-  UniversalHandler,
-  UniversalHandlerOptions,
-} from "./universal-handler.js";
+export type { UniversalHandlerOptions } from "./universal-handler.js";
 export type { ProtocolHandlerFactory } from "./protocol-handler-factory.js";
 export type { CommonTransportOptions } from "./transport-options.js";

--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -21,6 +21,8 @@ import type { AsyncIterableTransform } from "./async-iterable.js";
 /**
  * Invoke a user-provided implementation of a unary RPC. Returns a normalized
  * output message.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export async function invokeUnaryImplementation<
   I extends Message<I>,
@@ -38,6 +40,8 @@ export async function invokeUnaryImplementation<
  * Return an AsyncIterableTransform that invokes a user-provided implementation,
  * giving it input from an asynchronous iterable, and returning its output as an
  * asynchronous iterable.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function transformInvokeImplementation<
   I extends Message<I>,

--- a/packages/connect/src/protocol/limit-io.ts
+++ b/packages/connect/src/protocol/limit-io.ts
@@ -34,6 +34,8 @@ const defaultCompressMinBytes = 1024;
  * Asserts that the options writeMaxBytes, readMaxBytes, and compressMinBytes
  * are within sane limits, and returns default values where no value is
  * provided.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateReadWriteMaxBytes(
   readMaxBytes: number | undefined,
@@ -64,6 +66,8 @@ export function validateReadWriteMaxBytes(
 
 /**
  * Raise an error ResourceExhausted if more than writeMaxByte are written.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function assertWriteMaxBytes(
   writeMaxBytes: number,
@@ -79,6 +83,8 @@ export function assertWriteMaxBytes(
 
 /**
  * Raise an error ResourceExhausted if more than readMaxBytes are read.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function assertReadMaxBytes(
   readMaxBytes: number,

--- a/packages/connect/src/protocol/protocol-handler-factory.ts
+++ b/packages/connect/src/protocol/protocol-handler-factory.ts
@@ -18,6 +18,8 @@ import type { UniversalHandler } from "./universal-handler.js";
 /**
  * Creates a handler function for an RPC definition and an RPC implementation,
  * for one specific protocol.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface ProtocolHandlerFactory {
   /**

--- a/packages/connect/src/protocol/serialization.ts
+++ b/packages/connect/src/protocol/serialization.ts
@@ -29,6 +29,8 @@ import { assertReadMaxBytes, assertWriteMaxBytes } from "./limit-io.js";
 /**
  * Serialization provides methods to serialize or parse data with a certain
  * format.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface Serialization<T> {
   /**
@@ -45,6 +47,8 @@ export interface Serialization<T> {
 /**
  * Create an object that provides convenient access to request and response
  * message serialization for a given method.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createMethodSerializationLookup<
   I extends Message<I>,
@@ -87,6 +91,8 @@ export function createMethodSerializationLookup<
 /**
  * MethodSerializationLookup provides convenient access to request and response
  * message serialization for a given method.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface MethodSerializationLookup<
   I extends Message<I>,
@@ -105,6 +111,8 @@ export interface MethodSerializationLookup<
 /**
  * Returns functions to normalize and serialize the input message
  * of an RPC, and to parse the output message of an RPC.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createClientMethodSerializers<
   I extends Message<I>,
@@ -129,6 +137,8 @@ export function createClientMethodSerializers<
 
 /**
  * Apply I/O limits to a Serialization object, returning a new object.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function limitSerialization<T>(
   serialization: Serialization<T>,

--- a/packages/connect/src/protocol/transport-options.ts
+++ b/packages/connect/src/protocol/transport-options.ts
@@ -22,6 +22,9 @@ import type { UniversalClientFn } from "./universal.js";
 import type { Interceptor } from "../interceptor.js";
 import type { Compression } from "./compression.js";
 
+/**
+ * @private Internal code, does not follow semantic versioning.
+ */
 export interface CommonTransportOptions {
   /**
    * The HTTP client to use.

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -41,6 +41,8 @@ import { Code } from "../code.js";
 
 /**
  * Common options for handlers.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export interface UniversalHandlerOptions {
   /**
@@ -144,6 +146,8 @@ export interface UniversalHandler extends UniversalHandlerFn {
  * where no value is provided.
  *
  * Note that this function does not set default values for `acceptCompression`.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateUniversalHandlerOptions(
   opt: Partial<UniversalHandlerOptions> | undefined
@@ -176,6 +180,8 @@ export function validateUniversalHandlerOptions(
  * RPC. The handler serves the given protocols.
  *
  * At least one protocol is required.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createUniversalServiceHandlers(
   spec: ServiceImplSpec,
@@ -191,6 +197,8 @@ export function createUniversalServiceHandlers(
  * The handler serves the given protocols.
  *
  * At least one protocol is required.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function createUniversalMethodHandler(
   spec: MethodImplSpec,
@@ -209,6 +217,8 @@ export function createUniversalMethodHandler(
  *
  * Raises an error if no protocol handlers were provided, or if they do not
  * handle exactly the same RPC.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function negotiateProtocol(
   protocolHandlers: UniversalHandler[]

--- a/packages/connect/src/protocol/universal.ts
+++ b/packages/connect/src/protocol/universal.ts
@@ -86,6 +86,8 @@ export interface UniversalServerResponse {
  * the union type. A failure in such a call-sites indicates that
  * the contract between a server framework and the connect-node \
  * handler is broken.
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export function assertByteStreamRequest(
   req: UniversalServerRequest
@@ -104,18 +106,24 @@ export function assertByteStreamRequest(
 
 /**
  * HTTP 200 OK
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const uResponseOk: Readonly<UniversalServerResponse> = {
   status: 200,
 };
 /**
  * HTTP 404 Not Found
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const uResponseNotFound: Readonly<UniversalServerResponse> = {
   status: 404,
 };
 /**
  * HTTP 415 Unsupported Media Type
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const uResponseUnsupportedMediaType: Readonly<UniversalServerResponse> =
   {
@@ -123,12 +131,16 @@ export const uResponseUnsupportedMediaType: Readonly<UniversalServerResponse> =
   };
 /**
  * HTTP 405 Method Not Allowed
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const uResponseMethodNotAllowed: Readonly<UniversalServerResponse> = {
   status: 405,
 };
 /**
  * HTTP 505 Version Not Supported
+ *
+ * @private Internal code, does not follow semantic versioning.
  */
 export const uResponseVersionNotSupported: Readonly<UniversalServerResponse> = {
   status: 505,


### PR DESCRIPTION
The @bufbuild/connect package exports many types from subpath exports. Nearly all of them are for internal use, and only exported because we need them in the @bufbuild/connect-web package to provide gRPC-web and Connect Transports with minimal bundle size.

It is not feasible for us to support the huge API surface with the same stability promise as the main package exports. This PR marks all internal code with the `@private` JSDoc annotation. The `index.ts` files gives an explanation:

```ts
// All exports below are private — internal code that does not follow semantic
// versioning.
// We will try hard to avoid breaking changes, but if you depend on the
// following exports, we recommend that you do so with an exact version
// constraint (no ~ or ^).
```

Exports that are necessary to support other platforms and server frameworks are _not_ marked private. `createTransport()` and `createHandlerFactory()` from @bufbuild/protocol-connect and the other protocol subpaths, and the types for universal handlers and clients from @bufbuild/protocol are still part of the public API.