### PR TITLE
Upgrade to TypeScript 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^8.33.0",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.8.7",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.3"
       },
       "engines": {
         "node": ">=16",
@@ -5288,16 +5288,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/ua-parser-js": {
@@ -5643,7 +5643,7 @@
         "@bufbuild/protoc-gen-es": "^1.2.0",
         "@types/express": "^4.17.15",
         "esbuild": "^0.16.12",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.3"
       },
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "npm": ">=8"
   },
   "devDependencies": {
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.3",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
     "eslint": "^8.33.0",

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-express/src/express-connect-middleware.ts
+++ b/packages/connect-express/src/express-connect-middleware.ts
@@ -14,12 +14,11 @@
 
 import type { JsonValue } from "@bufbuild/protobuf";
 import {
-  ConnectRouter,
   createConnectRouter,
-  ConnectRouterOptions,
   Code,
   connectErrorFromReason,
 } from "@bufbuild/connect";
+import type { ConnectRouter, ConnectRouterOptions } from "@bufbuild/connect";
 import type { UniversalHandler } from "@bufbuild/connect/protocol";
 import { compressionBrotli, compressionGzip } from "@bufbuild/connect-node";
 import {

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-fastify/src/fastify-connect-plugin.ts
+++ b/packages/connect-fastify/src/fastify-connect-plugin.ts
@@ -16,10 +16,9 @@ import type { JsonValue } from "@bufbuild/protobuf";
 import {
   Code,
   connectErrorFromReason,
-  ConnectRouter,
-  ConnectRouterOptions,
   createConnectRouter,
 } from "@bufbuild/connect";
+import type { ConnectRouter, ConnectRouterOptions } from "@bufbuild/connect";
 import * as protoConnect from "@bufbuild/connect/protocol-connect";
 import * as protoGrpcWeb from "@bufbuild/connect/protocol-grpc-web";
 import * as protoGrpc from "@bufbuild/connect/protocol-grpc";

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-next/src/connect-nextjs-adapter.ts
+++ b/packages/connect-next/src/connect-nextjs-adapter.ts
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  ConnectRouter,
-  ConnectRouterOptions,
-  createConnectRouter,
-} from "@bufbuild/connect";
+import { createConnectRouter } from "@bufbuild/connect";
+import type { ConnectRouter, ConnectRouterOptions } from "@bufbuild/connect";
 import type { UniversalHandler } from "@bufbuild/connect/protocol";
 import {
   compressionBrotli,

--- a/packages/connect-node-test/package.json
+++ b/packages/connect-node-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/esm/*",
     "generate": "buf generate",
-    "build": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
+    "build": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm",
     "jasmine": "jasmine --config=jasmine.json"
   },
   "type": "module",

--- a/packages/connect-node-test/src/crosstest/timeout_on_sleeping_server.spec.ts
+++ b/packages/connect-node-test/src/crosstest/timeout_on_sleeping_server.spec.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import {
-  CallOptions,
   Code,
   ConnectError,
   createCallbackClient,
   createPromiseClient,
   connectErrorFromReason,
 } from "@bufbuild/connect";
+import type { CallOptions } from "@bufbuild/connect";
 import { TestService } from "../gen/grpc/testing/test_connect.js";
 import { StreamingOutputCallRequest } from "../gen/grpc/testing/messages_pb.js";
 import { createTestServers } from "../helpers/testserver.js";

--- a/packages/connect-node-test/src/express-readme.spec.ts
+++ b/packages/connect-node-test/src/express-readme.spec.ts
@@ -14,7 +14,8 @@
 
 import * as http from "http";
 import { Message, MethodKind, proto3 } from "@bufbuild/protobuf";
-import { ConnectRouter, createPromiseClient } from "@bufbuild/connect";
+import { createPromiseClient } from "@bufbuild/connect";
+import type { ConnectRouter } from "@bufbuild/connect";
 import { expressConnectMiddleware } from "@bufbuild/connect-express";
 import { createGrpcWebTransport } from "@bufbuild/connect-node";
 import { importExpress } from "./helpers/import-express.js";

--- a/packages/connect-node-test/src/extra/create-grpc-definition.ts
+++ b/packages/connect-node-test/src/extra/create-grpc-definition.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { MethodKind } from "@bufbuild/protobuf";
+import type {
   AnyMessage,
   BinaryReadOptions,
   BinaryWriteOptions,
-  MethodKind,
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";

--- a/packages/connect-node-test/src/helpers/test-routes.ts
+++ b/packages/connect-node-test/src/helpers/test-routes.ts
@@ -15,11 +15,10 @@
 import {
   Code,
   ConnectError,
-  ConnectRouter,
   decodeBinaryHeader,
   encodeBinaryHeader,
-  ServiceImpl,
 } from "@bufbuild/connect";
+import type { ConnectRouter, ServiceImpl } from "@bufbuild/connect";
 import { TestService } from "../gen/grpc/testing/test_connect.js";
 import type { StreamingOutputCallRequest } from "../gen/grpc/testing/messages_pb.js";
 import { interop } from "./interop.js";

--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -28,8 +28,8 @@ import {
 } from "@bufbuild/connect-node";
 import { fastifyConnectPlugin } from "@bufbuild/connect-fastify";
 import { expressConnectMiddleware } from "@bufbuild/connect-express";
-import {
-  fastify,
+import { fastify } from "fastify";
+import type {
   FastifyBaseLogger,
   FastifyInstance,
   FastifyTypeProviderDefault,

--- a/packages/connect-node-test/src/node-readme.spec.ts
+++ b/packages/connect-node-test/src/node-readme.spec.ts
@@ -14,7 +14,8 @@
 
 import * as http2 from "http2";
 import { Message, MethodKind, proto3 } from "@bufbuild/protobuf";
-import { ConnectRouter, createPromiseClient } from "@bufbuild/connect";
+import { createPromiseClient } from "@bufbuild/connect";
+import type { ConnectRouter } from "@bufbuild/connect";
 import {
   connectNodeAdapter,
   createGrpcTransport,

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "jasmine": "jasmine --config=jasmine.json"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/connect-node/src/connect-node-adapter.ts
+++ b/packages/connect-node/src/connect-node-adapter.ts
@@ -15,18 +15,19 @@
 import {
   Code,
   connectErrorFromReason,
-  ConnectRouter,
-  ConnectRouterOptions,
   createConnectRouter,
 } from "@bufbuild/connect";
+import type { ConnectRouter, ConnectRouterOptions } from "@bufbuild/connect";
 import type { UniversalHandler } from "@bufbuild/connect/protocol";
 import { uResponseNotFound } from "@bufbuild/connect/protocol";
 import {
+  universalRequestFromNodeRequest,
+  universalResponseToNodeResponse,
+} from "./node-universal-handler.js";
+import type {
   NodeHandlerFn,
   NodeServerRequest,
   NodeServerResponse,
-  universalRequestFromNodeRequest,
-  universalResponseToNodeResponse,
 } from "./node-universal-handler.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -21,10 +21,10 @@ import type {
 import type { Interceptor, Transport } from "@bufbuild/connect";
 import type { Compression } from "@bufbuild/connect/protocol";
 import { createTransport } from "@bufbuild/connect/protocol-connect";
-import {
+import { validateNodeTransportOptions } from "./validate-node-transport-options.js";
+import type {
   NodeHttp1TransportOptions,
   NodeHttp2TransportOptions,
-  validateNodeTransportOptions,
 } from "./validate-node-transport-options.js";
 
 /**

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 107,215 b | 46,955 b | 12,542 b |
+| connect        | 107,197 b | 46,935 b | 12,568 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 107,215 b | 46,955 b | 12,525 b |
+| connect        | 107,197 b | 46,935 b | 12,539 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect-web-test/package.json
+++ b/packages/connect-web-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/esm/*",
     "generate": "buf generate",
-    "build": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm",
+    "build": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm",
     "jasmine": "jasmine --config=jasmine.json",
     "karma": "karma start karma.conf.cjs",
     "karma-serve": "karma start karma.serve.conf.cjs",

--- a/packages/connect-web-test/src/cancellation.spec.ts
+++ b/packages/connect-web-test/src/cancellation.spec.ts
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 import {
-  CallOptions,
   Code,
   ConnectError,
   createCallbackClient,
   createPromiseClient,
 } from "@bufbuild/connect";
+import type { CallOptions } from "@bufbuild/connect";
 import { describeTransports } from "./helpers/crosstestserver.js";
 import { TestService } from "./gen/grpc/testing/test_connect.js";
 

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -12,32 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { Message, MethodKind } from "@bufbuild/protobuf";
+import type {
   AnyMessage,
   BinaryReadOptions,
   BinaryWriteOptions,
   JsonReadOptions,
   JsonValue,
   JsonWriteOptions,
-  Message,
   MethodInfo,
-  MethodKind,
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import type {
-  Interceptor,
-  Transport,
-  UnaryRequest,
-  UnaryResponse,
-} from "@bufbuild/connect";
 import {
   appendHeaders,
   Code,
   connectErrorFromReason,
   runStreaming,
   runUnary,
+} from "@bufbuild/connect";
+import type {
+  Interceptor,
   StreamResponse,
+  Transport,
+  UnaryRequest,
+  UnaryResponse,
 } from "@bufbuild/connect";
 import {
   createClientMethodSerializers,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { Message, MethodKind } from "@bufbuild/protobuf";
+import type {
   AnyMessage,
   BinaryReadOptions,
   BinaryWriteOptions,
   JsonReadOptions,
   JsonWriteOptions,
-  Message,
   MethodInfo,
-  MethodKind,
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
@@ -28,9 +27,11 @@ import type { UnaryRequest } from "@bufbuild/connect";
 import {
   Code,
   connectErrorFromReason,
-  Interceptor,
   runStreaming,
   runUnary,
+} from "@bufbuild/connect";
+import type {
+  Interceptor,
   StreamResponse,
   Transport,
   UnaryResponse,

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -21,8 +21,6 @@ export type { GrpcWebTransportOptions } from "./grpc-web-transport.js";
 // please please import from @bufbuild/connect instead
 // TODO(TCN-1261)
 import {
-  CallbackClient,
-  CallOptions,
   Code,
   ConnectError,
   connectErrorDetails,
@@ -31,6 +29,10 @@ import {
   createPromiseClient,
   decodeBinaryHeader,
   encodeBinaryHeader,
+} from "@bufbuild/connect";
+import type {
+  CallbackClient,
+  CallOptions,
   Interceptor,
   PromiseClient,
   StreamRequest,

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -14,7 +14,7 @@
     "generate": "buf generate src/protocol-grpc/proto",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types && echo >./dist/esm/package.json '{\"type\":\"module\", \"sideEffects\":false}'",
+    "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types && echo >./dist/esm/package.json '{\"type\":\"module\", \"sideEffects\":false}'",
     "jasmine": "jasmine --config=jasmine.json"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 import { Code } from "./code.js";
-import {
+import { createRegistry, Message } from "@bufbuild/protobuf";
+import type {
   AnyMessage,
-  createRegistry,
   IMessageTypeRegistry,
   JsonValue,
-  Message,
   MessageType,
 } from "@bufbuild/protobuf";
 import { codeToString } from "./protocol-connect/index.js";

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { Message, MethodKind } from "@bufbuild/protobuf";
+import type {
+  PartialMessage,
+  ServiceType,
   MethodInfo,
   MethodInfoBiDiStreaming,
   MethodInfoClientStreaming,
   MethodInfoServerStreaming,
   MethodInfoUnary,
-  PartialMessage,
-  ServiceType,
-  Message,
-  MethodKind,
 } from "@bufbuild/protobuf";
 import { createAsyncIterable } from "./protocol/index.js";
 import type { Transport } from "./transport.js";

--- a/packages/connect/src/protocol-connect/error-json.ts
+++ b/packages/connect/src/protocol-connect/error-json.ts
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { Message, protoBase64 } from "@bufbuild/protobuf";
+import type {
   JsonObject,
   JsonValue,
   JsonWriteOptions,
-  Message,
-  protoBase64,
 } from "@bufbuild/protobuf";
 import { Code } from "../code.js";
 import { ConnectError } from "../connect-error.js";

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -15,17 +15,13 @@
 import {
   Int32Value,
   Message,
-  MethodInfo,
   MethodKind,
-  ServiceType,
   StringValue,
 } from "@bufbuild/protobuf";
+import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
 import { createHandlerFactory } from "./handler-factory.js";
-import {
-  createMethodImplSpec,
-  HandlerContext,
-  MethodImpl,
-} from "../implementation.js";
+import { createMethodImplSpec } from "../implementation.js";
+import type { HandlerContext, MethodImpl } from "../implementation.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
 import { errorFromJsonBytes } from "./error-json.js";
 import { ConnectError } from "../connect-error.js";
@@ -79,8 +75,17 @@ describe("createHandlerFactory()", function () {
           yield new ctx.method.O();
         } as unknown as MethodImpl<M>;
         break;
-      default:
-        throw new Error("not implemented");
+      case MethodKind.ClientStreaming:
+      case MethodKind.BiDiStreaming:
+        implDefault = function (
+          // eslint-disable-next-line
+          req: AsyncIterable<Message>,
+          // eslint-disable-next-line
+          ctx: HandlerContext
+        ) {
+          throw new Error("not implemented");
+        } as unknown as MethodImpl<M>;
+        break;
     }
     const spec = createMethodImplSpec(
       opt.service ?? testService,

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -77,14 +77,9 @@ describe("createHandlerFactory()", function () {
         break;
       case MethodKind.ClientStreaming:
       case MethodKind.BiDiStreaming:
-        implDefault = function (
-          // eslint-disable-next-line
-          req: AsyncIterable<Message>,
-          // eslint-disable-next-line
-          ctx: HandlerContext
-        ) {
+        implDefault = (() => {
           throw new Error("not implemented");
-        } as unknown as MethodImpl<M>;
+        }) as unknown as MethodImpl<M>;
         break;
     }
     const spec = createMethodImplSpec(

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -12,25 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Message, MethodInfo, MethodKind } from "@bufbuild/protobuf";
+import { Message, MethodKind } from "@bufbuild/protobuf";
+import type { MethodInfo } from "@bufbuild/protobuf";
 import { ConnectError, connectErrorFromReason } from "../connect-error.js";
 import { Code } from "../code.js";
-import { createHandlerContext, MethodImplSpec } from "../implementation.js";
+import { createHandlerContext } from "../implementation.js";
+import type { MethodImplSpec } from "../implementation.js";
 import {
   assertByteStreamRequest,
-  Compression,
   compressionNegotiate,
   contentTypeMatcher,
   createMethodSerializationLookup,
   createMethodUrl,
-  EnvelopedMessage,
   invokeUnaryImplementation,
-  MethodSerializationLookup,
   validateUniversalHandlerOptions,
   pipe,
-  ProtocolHandlerFactory,
   readAllBytes,
-  Serialization,
   transformCatchFinally,
   transformCompressEnvelope,
   transformDecompressEnvelope,
@@ -40,13 +37,20 @@ import {
   transformPrepend,
   transformSerializeEnvelope,
   transformSplitEnvelope,
+  uResponseMethodNotAllowed,
+  uResponseOk,
+  uResponseUnsupportedMediaType,
+} from "../protocol/index.js";
+import type {
+  Compression,
+  EnvelopedMessage,
+  MethodSerializationLookup,
+  ProtocolHandlerFactory,
+  Serialization,
   UniversalHandlerFn,
   UniversalHandlerOptions,
   UniversalServerRequest,
   UniversalServerResponse,
-  uResponseMethodNotAllowed,
-  uResponseOk,
-  uResponseUnsupportedMediaType,
 } from "../protocol/index.js";
 import {
   contentTypeStreamJson,
@@ -57,11 +61,8 @@ import {
   contentTypeUnaryRegExp,
   parseContentType,
 } from "./content-type.js";
-import {
-  createEndStreamSerialization,
-  endStreamFlag,
-  EndStreamResponse,
-} from "./end-stream.js";
+import { createEndStreamSerialization, endStreamFlag } from "./end-stream.js";
+import type { EndStreamResponse } from "./end-stream.js";
 import {
   headerContentType,
   headerStreamAcceptEncoding,

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -25,6 +25,8 @@ import {
   ConnectError,
   runStreaming,
   runUnary,
+} from "../index.js";
+import type {
   StreamRequest,
   StreamResponse,
   Transport,
@@ -32,7 +34,6 @@ import {
   UnaryResponse,
 } from "../index.js";
 import {
-  CommonTransportOptions,
   createAsyncIterable,
   createMethodSerializationLookup,
   createMethodUrl,
@@ -47,6 +48,7 @@ import {
   transformSerializeEnvelope,
   transformSplitEnvelope,
 } from "../protocol/index.js";
+import type { CommonTransportOptions } from "../protocol/index.js";
 import { requestHeaderWithCompression } from "./request-header.js";
 import { headerUnaryContentLength, headerUnaryEncoding } from "./headers.js";
 import { validateResponseWithCompression } from "./validate-response.js";

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -15,18 +15,13 @@
 import type { Message } from "@bufbuild/protobuf";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
-import { MethodImplSpec, createHandlerContext } from "../implementation.js";
+import { createHandlerContext } from "../implementation.js";
+import type { MethodImplSpec } from "../implementation.js";
 import {
-  ProtocolHandlerFactory,
-  UniversalHandlerOptions,
   validateUniversalHandlerOptions,
-  UniversalServerRequest,
-  UniversalServerResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
-  Serialization,
-  EnvelopedMessage,
   assertByteStreamRequest,
   compressionNegotiate,
   contentTypeMatcher,
@@ -42,6 +37,13 @@ import {
   transformSplitEnvelope,
   transformCatchFinally,
   transformInvokeImplementation,
+} from "../protocol/index.js";
+import type { Serialization, EnvelopedMessage } from "../protocol/index.js";
+import type {
+  ProtocolHandlerFactory,
+  UniversalHandlerOptions,
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "../protocol/index.js";
 import { grpcStatusOk, setTrailerStatus } from "../protocol-grpc/index.js";
 import { createTrailerSerialization, trailerFlag } from "./trailer.js";

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -19,11 +19,8 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import {
-  Code,
-  ConnectError,
-  runStreaming,
-  runUnary,
+import { Code, ConnectError, runStreaming, runUnary } from "../index.js";
+import type {
   StreamRequest,
   StreamResponse,
   Transport,
@@ -31,7 +28,6 @@ import {
   UnaryResponse,
 } from "../index.js";
 import {
-  CommonTransportOptions,
   createAsyncIterable,
   createMethodSerializationLookup,
   createMethodUrl,
@@ -45,6 +41,7 @@ import {
   transformSerializeEnvelope,
   transformSplitEnvelope,
 } from "../protocol/index.js";
+import type { CommonTransportOptions } from "../protocol/index.js";
 import { validateTrailer } from "../protocol-grpc/validate-trailer.js";
 import { requestHeaderWithCompression } from "./request-header.js";
 import { validateResponseWithCompression } from "./validate-response.js";

--- a/packages/connect/src/protocol-grpc/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.ts
@@ -13,15 +13,12 @@
 // limitations under the License.
 
 import type { Message } from "@bufbuild/protobuf";
-import { createHandlerContext, MethodImplSpec } from "../implementation.js";
+import { createHandlerContext } from "../implementation.js";
+import type { MethodImplSpec } from "../implementation.js";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
 import {
-  ProtocolHandlerFactory,
-  UniversalHandlerOptions,
   validateUniversalHandlerOptions,
-  UniversalServerRequest,
-  UniversalServerResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
@@ -40,6 +37,12 @@ import {
   transformSerializeEnvelope,
   transformSplitEnvelope,
   transformInvokeImplementation,
+} from "../protocol/index.js";
+import type {
+  ProtocolHandlerFactory,
+  UniversalHandlerOptions,
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "../protocol/index.js";
 import {
   contentTypeJson,

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -19,11 +19,8 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import {
-  Code,
-  ConnectError,
-  runStreaming,
-  runUnary,
+import { Code, ConnectError, runStreaming, runUnary } from "../index.js";
+import type {
   StreamRequest,
   StreamResponse,
   Transport,
@@ -31,7 +28,6 @@ import {
   UnaryResponse,
 } from "../index.js";
 import {
-  CommonTransportOptions,
   createAsyncIterable,
   createMethodSerializationLookup,
   createMethodUrl,
@@ -45,6 +41,7 @@ import {
   transformSerializeEnvelope,
   transformSplitEnvelope,
 } from "../protocol/index.js";
+import type { CommonTransportOptions } from "../protocol/index.js";
 import { requestHeaderWithCompression } from "./request-header.js";
 import { validateResponseWithCompression } from "./validate-response.js";
 import { validateTrailer } from "./validate-trailer.js";

--- a/packages/connect/src/protocol/async-iterable-story.spec.ts
+++ b/packages/connect/src/protocol/async-iterable-story.spec.ts
@@ -32,8 +32,8 @@ import {
   transformParseEnvelope,
   createAsyncIterable,
   createWritableIterable,
-  WritableIterable,
 } from "./async-iterable.js";
+import type { WritableIterable } from "./async-iterable.js";
 
 // These tests aim to model the usage of iterable transforms in clients and servers.
 // Note that the tests were written as a proof of concept, and the coverage is

--- a/packages/connect/src/protocol/compression.spec.ts
+++ b/packages/connect/src/protocol/compression.spec.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Compression, compressionNegotiate } from "./compression.js";
+import { compressionNegotiate } from "./compression.js";
+import type { Compression } from "./compression.js";
 import { ConnectError } from "../connect-error.js";
 import { node16FetchHeadersPolyfill } from "../node16-polyfill-helper.spec.js";
 

--- a/packages/connect/src/protocol/envelope.spec.ts
+++ b/packages/connect/src/protocol/envelope.spec.ts
@@ -17,8 +17,8 @@ import {
   encodeEnvelopes,
   envelopeCompress,
   envelopeDecompress,
-  EnvelopedMessage,
 } from "./envelope.js";
+import type { EnvelopedMessage } from "./envelope.js";
 import type { Compression } from "./compression.js";
 import { ConnectError, connectErrorFromReason } from "../connect-error.js";
 import { Code } from "../code.js";

--- a/packages/connect/src/protocol/envelope.ts
+++ b/packages/connect/src/protocol/envelope.ts
@@ -14,7 +14,8 @@
 
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
-import { compressedFlag, Compression } from "./compression.js";
+import { compressedFlag } from "./compression.js";
+import type { Compression } from "./compression.js";
 
 /**
  * Represents an Enveloped-Message of the Connect protocol.

--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Message, MethodKind, PartialMessage } from "@bufbuild/protobuf";
+import { Message, MethodKind } from "@bufbuild/protobuf";
+import type { PartialMessage } from "@bufbuild/protobuf";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
 import type { HandlerContext, MethodImplSpec } from "../implementation.js";

--- a/packages/connect/src/protocol/serialization.spec.ts
+++ b/packages/connect/src/protocol/serialization.spec.ts
@@ -17,8 +17,8 @@ import {
   createBinarySerialization,
   createJsonSerialization,
   limitSerialization,
-  Serialization,
 } from "./serialization.js";
+import type { Serialization } from "./serialization.js";
 import { ConnectError, connectErrorFromReason } from "../connect-error.js";
 
 describe("createBinarySerialization()", function () {

--- a/packages/connect/src/protocol/universal-handler.spec.ts
+++ b/packages/connect/src/protocol/universal-handler.spec.ts
@@ -16,9 +16,11 @@ import type { ServiceType } from "@bufbuild/protobuf";
 import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
 import {
   negotiateProtocol,
+  validateUniversalHandlerOptions,
+} from "./universal-handler.js";
+import type {
   UniversalHandler,
   UniversalHandlerOptions,
-  validateUniversalHandlerOptions,
 } from "./universal-handler.js";
 import type { Compression } from "./compression.js";
 import { contentTypeMatcher } from "./content-type-matcher.js";

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import { MethodKind } from "@bufbuild/protobuf";
+import type {
   BinaryReadOptions,
   BinaryWriteOptions,
   JsonReadOptions,
   JsonWriteOptions,
   MethodInfo,
-  MethodKind,
   ServiceType,
 } from "@bufbuild/protobuf";
 import type { MethodImplSpec, ServiceImplSpec } from "../implementation.js";
 import {
-  UniversalHandlerFn,
-  UniversalServerRequest,
   uResponseMethodNotAllowed,
   uResponseUnsupportedMediaType,
   uResponseVersionNotSupported,
 } from "./universal.js";
-import {
-  ContentTypeMatcher,
-  contentTypeMatcher,
-} from "./content-type-matcher.js";
+import type {
+  UniversalHandlerFn,
+  UniversalServerRequest,
+} from "./universal.js";
+import { contentTypeMatcher } from "./content-type-matcher.js";
+import type { ContentTypeMatcher } from "./content-type-matcher.js";
 import type { Compression } from "./compression.js";
 import type { ProtocolHandlerFactory } from "./protocol-handler-factory.js";
 import { validateReadWriteMaxBytes } from "./limit-io.js";

--- a/packages/connect/src/router-transport.ts
+++ b/packages/connect/src/router-transport.ts
@@ -15,11 +15,8 @@
 import { createTransport } from "./protocol-connect/transport.js";
 import type { CommonTransportOptions } from "./protocol/transport-options.js";
 import { createUniversalHandlerClient } from "./protocol/universal-handler-client.js";
-import {
-  ConnectRouter,
-  ConnectRouterOptions,
-  createConnectRouter,
-} from "./router.js";
+import { createConnectRouter } from "./router.js";
+import type { ConnectRouter, ConnectRouterOptions } from "./router.js";
 
 /**
  * Creates a Transport that routes requests to the configured router. Useful for testing

--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -18,16 +18,17 @@ import { Code } from "./code.js";
 import {
   createMethodImplSpec,
   createServiceImplSpec,
-  MethodImpl,
-  ServiceImpl,
 } from "./implementation.js";
+import type { MethodImpl, ServiceImpl } from "./implementation.js";
 import {
-  ProtocolHandlerFactory,
-  UniversalHandler,
-  UniversalHandlerOptions,
   validateUniversalHandlerOptions,
   createUniversalMethodHandler,
   createUniversalServiceHandlers,
+} from "./protocol/index.js";
+import type {
+  ProtocolHandlerFactory,
+  UniversalHandler,
+  UniversalHandlerOptions,
 } from "./protocol/index.js";
 import { createHandlerFactory as handlerFactoryGrpcWeb } from "./protocol-grpc-web/handler-factory.js";
 import { createHandlerFactory as handlerFactoryGrpc } from "./protocol-grpc/handler-factory.js";

--- a/packages/connect/src/transport-stub.ts
+++ b/packages/connect/src/transport-stub.ts
@@ -20,10 +20,9 @@ import type {
 } from "@bufbuild/protobuf";
 import type { Transport } from "./transport.js";
 import type { ConnectError } from "./connect-error.js";
-import {
+import { runStreaming, runUnary } from "./interceptor.js";
+import type {
   Interceptor,
-  runStreaming,
-  runUnary,
   StreamResponse,
   StreamRequest,
   UnaryRequest,

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -23,6 +23,6 @@
     "@bufbuild/protoc-gen-es": "^1.2.0",
     "@types/express": "^4.17.15",
     "esbuild": "^0.16.12",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   }
 }

--- a/packages/example/src/server.ts
+++ b/packages/example/src/server.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ConnectRouter } from "@bufbuild/connect";
+import type { ConnectRouter } from "@bufbuild/connect";
 import { connectNodeAdapter } from "@bufbuild/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 import type {

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -8,13 +8,13 @@
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "esModuleInterop": true,
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,6 @@
       "ES2018.AsyncIterable"
     ],
     "esModuleInterop": false,
-    "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": true,
@@ -26,9 +25,6 @@
 
     // We need node's module resolution, so we do not have to skip lib checks
     "moduleResolution": "Node",
-    "skipLibCheck": false,
-
-    // To support bundlers that transpile files in isolation
-    "isolatedModules": true
+    "skipLibCheck": false
   }
 }


### PR DESCRIPTION
This upgrades Connect-ES' packages to use TypeScript 5.0.3. 

The major change was to accommodate the new [`verbatimModuleSyntax`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax) flag. This required removing the usage of `importsNotUsedAsValues` from our main tsconfig and applying the new flag to any build commands generating ESM output. Note that we can't use this in our main `tsconfig.base.json` because it isn't permitted when the module output is CJS.

For consistency, this flag was used in all the CLI commands for generating ESM. The only place where it was put into the actual `tsconfig.json` was for the `example`.