### PR TITLE
Fix transport options type import

### DIFF
--- a/packages/connect-node/src/validate-node-transport-options.ts
+++ b/packages/connect-node/src/validate-node-transport-options.ts
@@ -21,7 +21,7 @@ import {
   createNodeHttp1Client,
   createNodeHttp2Client,
 } from "./node-universal-client.js";
-import type { CommonTransportOptions } from "@bufbuild/connect/src/protocol";
+import type { CommonTransportOptions } from "@bufbuild/connect/protocol";
 
 /**
  * Options specific to the Node.js built in http and https modules.


### PR DESCRIPTION
This PR fixes TypeScript compilation errors introduced in 0.8.5 (https://github.com/bufbuild/connect-es/pull/546):

```
node_modules/@bufbuild/connect-node/dist/types/validate-node-transport-options.d.ts:7:45 - error TS2307: Cannot find module '@bufbuild/connect/src/protocol' or its corresponding type declarations.

7 import type { CommonTransportOptions } from "@bufbuild/connect/src/protocol";
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@bufbuild/connect-node/dist/types/validate-node-transport-options.d.ts:46:29 - error TS2307: Cannot find module '@bufbuild/connect/src/protocol' or its corresponding type declarations.

46     sendCompression: import("@bufbuild/connect/src/protocol").Compression | null;
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@bufbuild/connect-node/dist/types/validate-node-transport-options.d.ts:47:31 - error TS2307: Cannot find module '@bufbuild/connect/src/protocol' or its corresponding type declarations.

47     acceptCompression: import("@bufbuild/connect/src/protocol").Compression[];
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@bufbuild/connect-node/dist/types/validate-node-transport-options.d.ts:53:26 - error TS2307: Cannot find module '@bufbuild/connect/src/interceptor.js' or its corresponding type declarations.

53     interceptors: import("@bufbuild/connect/src/interceptor.js").Interceptor[];
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 4 errors.
```