### PR TITLE
Add test coverage for parsing timeout zero in gRPC and Connect

### DIFF
--- a/packages/connect/src/protocol-connect/parse-timeout.spec.ts
+++ b/packages/connect/src/protocol-connect/parse-timeout.spec.ts
@@ -19,6 +19,7 @@ describe("parseTimeout()", function () {
   it("should parse proper timeout", () => {
     expect(parseTimeout("1")).toEqual(1);
     expect(parseTimeout("1234567890")).toEqual(1234567890);
+    expect(parseTimeout("0")).toEqual(0);
   });
   it("should should return undefined for null value", () => {
     expect(parseTimeout(null)).toEqual(undefined);

--- a/packages/connect/src/protocol-grpc/parse-timeout.spec.ts
+++ b/packages/connect/src/protocol-grpc/parse-timeout.spec.ts
@@ -25,6 +25,7 @@ describe("parseTimeout()", function () {
     expect(parseTimeout("1000u")).toEqual(1);
     expect(parseTimeout("1000000n")).toEqual(1);
     expect(parseTimeout("0n")).toEqual(0);
+    expect(parseTimeout("0H")).toEqual(0);
   });
   it("should should return undefined for null value", () => {
     expect(parseTimeout(null)).toEqual(undefined);

--- a/packages/connect/src/protocol-grpc/parse-timeout.spec.ts
+++ b/packages/connect/src/protocol-grpc/parse-timeout.spec.ts
@@ -24,6 +24,7 @@ describe("parseTimeout()", function () {
     expect(parseTimeout("1m")).toEqual(1);
     expect(parseTimeout("1000u")).toEqual(1);
     expect(parseTimeout("1000000n")).toEqual(1);
+    expect(parseTimeout("0n")).toEqual(0);
   });
   it("should should return undefined for null value", () => {
     expect(parseTimeout(null)).toEqual(undefined);


### PR DESCRIPTION
The implementations for parsing timeout values already handle zero values, for example `0H` for gRCP. 
This adds coverage to clarify that this is intentional, although the spec is vague ("positive integer").