### PR TITLE
Support timeouts in handlers

### DIFF
--- a/packages/connect-node-test/src/helpers/test-routes.ts
+++ b/packages/connect-node-test/src/helpers/test-routes.ts
@@ -69,6 +69,7 @@ const testService: ServiceImpl<typeof TestService> = {
     );
     for (const param of request.responseParameters) {
       await maybeDelayResponse(param);
+      context.deadline?.throwIfAborted();
       yield {
         payload: interop.makeServerPayload(request.responseType, param.size),
       };
@@ -84,6 +85,7 @@ const testService: ServiceImpl<typeof TestService> = {
     );
     for (const param of request.responseParameters) {
       await maybeDelayResponse(param);
+      context.deadline?.throwIfAborted();
       yield {
         payload: interop.makeServerPayload(request.responseType, param.size),
       };
@@ -117,6 +119,7 @@ const testService: ServiceImpl<typeof TestService> = {
     for await (const req of requests) {
       for (const param of req.responseParameters) {
         await maybeDelayResponse(param);
+        context.deadline?.throwIfAborted();
         yield {
           payload: interop.makeServerPayload(req.responseType, param.size),
         };
@@ -138,6 +141,7 @@ const testService: ServiceImpl<typeof TestService> = {
     for await (const req of buffer) {
       for (const param of req.responseParameters) {
         await maybeDelayResponse(param);
+        context.deadline?.throwIfAborted();
         yield {
           payload: interop.makeServerPayload(req.responseType, param.size),
         };

--- a/packages/connect-web-test/src/crosstest/timeout_on_sleeping_server.spec.ts
+++ b/packages/connect-web-test/src/crosstest/timeout_on_sleeping_server.spec.ts
@@ -21,7 +21,7 @@ import {
   connectErrorFromReason,
 } from "@bufbuild/connect";
 import { TestService } from "../gen/grpc/testing/test_connect.js";
-import { describeTransportsExcluding } from "../helpers/crosstestserver.js";
+import { describeTransports } from "../helpers/crosstestserver.js";
 import { StreamingOutputCallRequest } from "../gen/grpc/testing/messages_pb.js";
 
 describe("timeout_on_sleeping_server", function () {
@@ -39,48 +39,39 @@ describe("timeout_on_sleeping_server", function () {
   const options: CallOptions = {
     timeoutMs: 5,
   };
-  // TODO(TCN-761) support deadlines in connect-es handlers
-  describeTransportsExcluding(
-    [
-      "@bufbuild/connect-web (Connect, JSON) against @bufbuild/connect-node (h1)",
-      "@bufbuild/connect-web (Connect, binary) against @bufbuild/connect-node (h1)",
-      "@bufbuild/connect-web (gRPC-web, binary) gRPC-web against @bufbuild/connect-node (h1)",
-      "@bufbuild/connect-web (gRPC-web, JSON) gRPC-web against @bufbuild/connect-node (h1)",
-    ],
-    (transport) => {
-      it("with promise client", async function () {
-        const client = createPromiseClient(TestService, transport());
-        try {
-          for await (const response of client.streamingOutputCall(
-            request,
-            options
-          )) {
-            fail(
-              `expecting no response from sleeping server, got: ${response.toJsonString()}`
-            );
-          }
-          fail("expected to catch an error");
-        } catch (e) {
-          expect(e).toBeInstanceOf(ConnectError);
-          expect(connectErrorFromReason(e).code).toBe(Code.DeadlineExceeded);
-        }
-      });
-      it("with callback client", function (done) {
-        const client = createCallbackClient(TestService, transport());
-        client.streamingOutputCall(
+  describeTransports((transport) => {
+    it("with promise client", async function () {
+      const client = createPromiseClient(TestService, transport());
+      try {
+        for await (const response of client.streamingOutputCall(
           request,
-          (response) => {
-            fail(
-              `expecting no response from sleeping server, got: ${response.toJsonString()}`
-            );
-          },
-          (err: ConnectError | undefined) => {
-            expect(err?.code).toBe(Code.DeadlineExceeded);
-            done();
-          },
           options
-        );
-      });
-    }
-  );
+        )) {
+          fail(
+            `expecting no response from sleeping server, got: ${response.toJsonString()}`
+          );
+        }
+        fail("expected to catch an error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).code).toBe(Code.DeadlineExceeded);
+      }
+    });
+    it("with callback client", function (done) {
+      const client = createCallbackClient(TestService, transport());
+      client.streamingOutputCall(
+        request,
+        (response) => {
+          fail(
+            `expecting no response from sleeping server, got: ${response.toJsonString()}`
+          );
+        },
+        (err: ConnectError | undefined) => {
+          expect(err?.code).toBe(Code.DeadlineExceeded);
+          done();
+        },
+        options
+      );
+    });
+  });
 });

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -71,6 +71,9 @@ export interface HandlerContext {
    */
   readonly service: ServiceType;
 
+  // TODO
+  readonly deadline?: AbortSignal;
+
   /**
    * Incoming request headers.
    */
@@ -95,13 +98,15 @@ export interface HandlerContext {
  */
 export function createHandlerContext(
   spec: { service: ServiceType; method: MethodInfo },
+  deadline: AbortSignal | undefined, // TODO
   requestHeader: HeadersInit,
   responseHeader: HeadersInit,
-  responseTrailer?: HeadersInit
+  responseTrailer: HeadersInit
 ): HandlerContext {
   return {
     method: spec.method,
     service: spec.service,
+    deadline,
     requestHeader: new Headers(requestHeader),
     responseHeader: new Headers(responseHeader),
     responseTrailer: new Headers(responseTrailer),

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -17,12 +17,17 @@ import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
 import { createHandlerFactory } from "./handler-factory.js";
 import type { MethodImpl } from "../implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
-import type { UniversalHandlerOptions } from "../protocol/index.js";
+import type {
+  UniversalHandlerOptions,
+  UniversalServerResponse,
+} from "../protocol/index.js";
 import {
   createAsyncIterable,
   createUniversalHandlerClient,
+  encodeEnvelope,
   pipeTo,
   sinkAll,
+  transformSplitEnvelope,
 } from "../protocol/index.js";
 import { ConnectError } from "../connect-error.js";
 import {
@@ -33,6 +38,7 @@ import { Code } from "../code.js";
 import { errorFromJsonBytes } from "./error-json.js";
 import { endStreamFromJson } from "./end-stream.js";
 import { createTransport } from "./transport.js";
+import { requestHeader } from "./request-header.js";
 
 describe("createHandlerFactory()", function () {
   const testService = {
@@ -230,6 +236,100 @@ describe("createHandlerFactory()", function () {
           expect(end.error?.message).toBe(
             '[invalid_argument] Connect-Protocol-Version must be "1": got "UNEXPECTED"'
           );
+        }
+      });
+    });
+  });
+
+  describe("deadlines", function () {
+    describe("unary", function () {
+      it("should raise an error with code DEADLINE_EXCEEDED if exceeded", async function () {
+        const timeoutMs = 1;
+        const { handler, service, method } = setupTestHandler(
+          testService.methods.foo,
+          {},
+          async (req, ctx) => {
+            await new Promise((r) => setTimeout(r, timeoutMs + 50));
+            ctx.deadline?.throwIfAborted();
+            return { value: req.value.toString(10) };
+          }
+        );
+        const res = await handler({
+          httpVersion: "2.0",
+          method: "POST",
+          url: new URL(
+            `https://example.com/${service.typeName}/${method.name}`
+          ),
+          header: requestHeader(method.kind, true, timeoutMs, undefined),
+          body: createAsyncIterable([new Uint8Array(0)]),
+        });
+        expect(res.status).toBe(408);
+        expect(res.body).toBeDefined();
+        if (res.body !== undefined) {
+          const bodyBytes =
+            res.body instanceof Uint8Array
+              ? res.body
+              : await readAllBytes(res.body);
+          const err = errorFromJsonBytes(
+            bodyBytes,
+            undefined,
+            new ConnectError("error parse failed")
+          );
+          expect(err.code).toBe(Code.DeadlineExceeded);
+          expect(err.message).toBe(
+            "[deadline_exceeded] the operation timed out"
+          );
+        }
+      });
+    });
+    describe("streaming", function () {
+      async function getLastEnvelope(res: UniversalServerResponse) {
+        expect(res.body).toBeDefined();
+        expect(res.body).not.toBeInstanceOf(Uint8Array);
+        if (res.body !== undefined && Symbol.asyncIterator in res.body) {
+          const envelopes = await pipeTo(
+            res.body,
+            transformSplitEnvelope(0xffffff),
+            sinkAll()
+          );
+          const last = envelopes.pop();
+          expect(last).toBeDefined();
+          return last;
+        }
+        return undefined;
+      }
+
+      it("should raise an error with code DEADLINE_EXCEEDED if exceeded", async function () {
+        const timeoutMs = 1;
+        const { handler, service, method } = setupTestHandler(
+          testService.methods.bar,
+          {},
+          async function* (req, ctx) {
+            await new Promise((r) => setTimeout(r, timeoutMs + 50));
+            ctx.deadline?.throwIfAborted();
+            yield { value: req.value.toString(10) };
+          }
+        );
+        const res = await handler({
+          httpVersion: "2.0",
+          method: "POST",
+          url: new URL(
+            `https://example.com/${service.typeName}/${method.name}`
+          ),
+          header: requestHeader(method.kind, true, timeoutMs, undefined),
+          body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
+        });
+        expect(res.status).toBe(200);
+        expect(res.body).toBeDefined();
+        if (res.body !== undefined) {
+          const lastEnv = await getLastEnvelope(res);
+          if (lastEnv !== undefined) {
+            const end = endStreamFromJson(lastEnv.data);
+            expect(end.error?.code).toBe(Code.DeadlineExceeded);
+            expect(end.error?.message).toBe(
+              "[deadline_exceeded] the operation timed out"
+            );
+          }
         }
       });
     });

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -104,7 +104,7 @@ export function createHandlerFactory(
     );
     const parseDeadline = createDeadlineParser(
       parseTimeout,
-      opt.maxDeadlineDurationMs,
+      opt.maxTimeoutMs,
       opt.shutdownSignal
     );
     switch (spec.kind) {

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -108,7 +108,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
   );
   const parseDeadline = createDeadlineParser(
     parseTimeout,
-    opt.maxDeadlineDurationMs,
+    opt.maxTimeoutMs,
     opt.shutdownSignal
   );
 

--- a/packages/connect/src/protocol-grpc/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.ts
@@ -100,7 +100,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
   );
   const parseDeadline = createDeadlineParser(
     parseTimeout,
-    opt.maxDeadlineDurationMs,
+    opt.maxTimeoutMs,
     opt.shutdownSignal
   );
 

--- a/packages/connect/src/protocol/deadline-factory.spec.ts
+++ b/packages/connect/src/protocol/deadline-factory.spec.ts
@@ -1,0 +1,106 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createDeadlineSignal,
+  createDeadlineParser,
+} from "./deadline-factory.js";
+import { ConnectError } from "../connect-error.js";
+import { Code } from "../code.js";
+
+describe("createDeadlineParser()", function () {
+  describe("with invalid input", function () {
+    const parseValue = () =>
+      new ConnectError("not a timeout", Code.InvalidArgument);
+    const parseDeadline = createDeadlineParser(parseValue, 99, undefined);
+    it("should return an error", function () {
+      const d = parseDeadline("foo");
+      expect(d.error).toBeDefined();
+      expect(d.error?.code).toBe(Code.InvalidArgument);
+      expect(d.signal).toBeUndefined();
+      expect(d.cleanup).toBeUndefined();
+    });
+  });
+  describe("with max duration", function () {
+    const parseDeadline = createDeadlineParser(() => 1000, 0, undefined);
+    it("should raise error", function () {
+      const d = parseDeadline("irrelevant");
+      expect(d.error?.code).toBe(Code.InvalidArgument);
+      expect(d.error?.message).toBe(
+        "[invalid_argument] timeout 1000ms must be <= 0ms"
+      );
+      expect(d.signal).toBeUndefined();
+      expect(d.cleanup).toBeUndefined();
+    });
+  });
+});
+
+describe("createDeadlineSignal()", function () {
+  describe("initially", function () {
+    it("should not be aborted", function () {
+      const d = createDeadlineSignal(100, undefined);
+      expect(d.signal.aborted).toBeFalse();
+    });
+    it("should not be aborted initially", function () {
+      const d = createDeadlineSignal(100, undefined);
+      expect(d.signal).toBeDefined();
+      expect(d.cleanup).toBeDefined();
+    });
+  });
+  describe("with aborted shutdown signal", function () {
+    it("should be aborted immediately", function () {
+      const s = new AbortController();
+      s.abort();
+      const d = createDeadlineSignal(100, s.signal);
+      expect(d.signal.aborted).toBeTrue();
+    });
+  });
+  describe("with 0 timeout", function () {
+    it("should be aborted immediately", function () {
+      const d = createDeadlineSignal(0, undefined);
+      expect(d.signal.aborted).toBeTrue();
+    });
+  });
+  it("should be aborted after timeout", async function () {
+    const timeoutMs = 5;
+    const d = createDeadlineSignal(timeoutMs, undefined);
+    await new Promise((resolve) => setTimeout(resolve, timeoutMs + 25));
+    expect(d.signal.aborted).toBeTrue();
+    expect(String(d.signal.reason)).toEqual(
+      "ConnectError: [deadline_exceeded] the operation timed out"
+    );
+  });
+  it("should be aborted when shut down", async function () {
+    const s = new AbortController();
+    const d = createDeadlineSignal(100, s.signal);
+    s.abort();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(d.signal.aborted).toBeTrue();
+    expect(String(d.signal.reason)).toEqual(
+      "ConnectError: [unavailable] going away"
+    );
+  });
+  it("should surface shutdown reason via cause", function () {
+    const s = new AbortController();
+    s.abort(new Error("cause"));
+    const d = createDeadlineSignal(100, s.signal);
+    expect(d.signal.aborted).toBeTrue();
+    expect(String(d.signal.reason)).toEqual(
+      "ConnectError: [unavailable] going away"
+    );
+    if (d.signal.reason instanceof ConnectError) {
+      expect(d.signal.reason.cause).toEqual(new Error("cause"));
+    }
+  });
+});

--- a/packages/connect/src/protocol/deadline-factory.ts
+++ b/packages/connect/src/protocol/deadline-factory.ts
@@ -1,0 +1,143 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConnectError } from "../connect-error.js";
+import { Code } from "../code.js";
+
+/**
+ * A function that parses a timeout value, and creates a deadline.
+ *
+ * @private Internal code, does not follow semantic versioning.
+ */
+export type ParseDeadlineFn = (timeoutValue: string | null) =>
+  | {
+      error: ConnectError;
+      signal?: undefined;
+      cleanup?: undefined;
+    }
+  | {
+      error?: undefined;
+      signal: AbortSignal;
+      cleanup: () => void;
+    };
+
+/**
+ * Create a function that parses a timeout value with the given parser function,
+ * and creates a deadline.
+ *
+ * @private Internal code, does not follow semantic versioning.
+ */
+export function createDeadlineParser(
+  parser: (value: string | null) => number | undefined | ConnectError,
+  maxDeadlineDurationMs: number,
+  shutdownSignal: AbortSignal | undefined
+): ParseDeadlineFn {
+  return function parseDeadline(value: string | null) {
+    const timeoutMs = parser(value);
+    if (timeoutMs instanceof ConnectError) {
+      return { error: timeoutMs };
+    }
+    if (timeoutMs !== undefined) {
+      if (timeoutMs > maxDeadlineDurationMs) {
+        return {
+          error: new ConnectError(
+            `timeout ${timeoutMs}ms must be <= ${maxDeadlineDurationMs}ms`,
+            Code.InvalidArgument
+          ),
+        };
+      }
+    }
+    return createDeadlineSignal(timeoutMs, shutdownSignal);
+  };
+}
+
+/**
+ * Create a deadline, a signal for an operation to end. The returned object
+ * contains an AbortSignal, but also a cleanup function that must be called
+ * once the calling code is no longer interested in the signal.
+ *
+ * Ideally, we would simply use AbortSignal.timeout(), but it is not widely
+ * available yet, and we also want to chain a signal for graceful shutdown.
+ *
+ * @private Internal code, does not follow semantic versioning.
+ */
+export function createDeadlineSignal(
+  timeoutMs: number | undefined,
+  shutdownSignal: AbortSignal | undefined
+): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const cleanups: (() => void)[] = [];
+  if (timeoutMs !== undefined) {
+    const listener = () => controller.abort(errTimeout());
+    if (timeoutMs <= 0) {
+      listener();
+    } else {
+      const timeoutId = setTimeout(listener, timeoutMs);
+      cleanups.push(() => clearTimeout(timeoutId));
+    }
+  }
+  if (shutdownSignal) {
+    const listener = () => controller.abort(errShutdown(shutdownSignal.reason));
+    if (shutdownSignal.aborted) {
+      listener();
+    } else {
+      shutdownSignal.addEventListener("abort", listener);
+      cleanups.push(() =>
+        shutdownSignal.removeEventListener("abort", listener)
+      );
+    }
+  }
+  polyfillThrowIfAborted(controller.signal, shutdownSignal);
+  return {
+    signal: controller.signal,
+    cleanup: () => cleanups.map((fn) => fn()),
+  };
+}
+
+function errTimeout() {
+  return new ConnectError("the operation timed out", Code.DeadlineExceeded);
+}
+
+function errShutdown(cause?: unknown) {
+  return new ConnectError(
+    "going away",
+    Code.Unavailable,
+    undefined,
+    undefined,
+    cause
+  );
+}
+
+// Polyfill missing throwIfAborted for Node.js < 17.3.0.
+function polyfillThrowIfAborted(
+  signal: AbortSignal,
+  shutdownSignal: AbortSignal | undefined
+) {
+  if ("throwIfAborted" in signal) {
+    return;
+  }
+  const s = signal as AbortSignal;
+  s.throwIfAborted = function () {
+    if (s.aborted) {
+      // AbortSignal.reason was added in Node.js 17.2.0, we cannot rely on it either.
+      throw (
+        s.reason ??
+        (shutdownSignal?.aborted === true ? errShutdown() : errTimeout())
+      );
+    }
+  };
+}

--- a/packages/connect/src/protocol/deadline-factory.ts
+++ b/packages/connect/src/protocol/deadline-factory.ts
@@ -40,7 +40,7 @@ export type ParseDeadlineFn = (timeoutValue: string | null) =>
  */
 export function createDeadlineParser(
   parser: (value: string | null) => number | undefined | ConnectError,
-  maxDeadlineDurationMs: number,
+  maxTimeoutMs: number,
   shutdownSignal: AbortSignal | undefined
 ): ParseDeadlineFn {
   return function parseDeadline(value: string | null) {
@@ -49,10 +49,10 @@ export function createDeadlineParser(
       return { error: timeoutMs };
     }
     if (timeoutMs !== undefined) {
-      if (timeoutMs > maxDeadlineDurationMs) {
+      if (timeoutMs > maxTimeoutMs) {
         return {
           error: new ConnectError(
-            `timeout ${timeoutMs}ms must be <= ${maxDeadlineDurationMs}ms`,
+            `timeout ${timeoutMs}ms must be <= ${maxTimeoutMs}ms`,
             Code.InvalidArgument
           ),
         };

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -85,6 +85,8 @@ export {
   invokeUnaryImplementation,
   transformInvokeImplementation,
 } from "./invoke-implementation.js";
+export type { ParseDeadlineFn } from "./deadline-factory.js";
+export { createDeadlineParser } from "./deadline-factory.js";
 export {
   assertByteStreamRequest,
   uResponseOk,

--- a/packages/connect/src/protocol/universal-handler.spec.ts
+++ b/packages/connect/src/protocol/universal-handler.spec.ts
@@ -36,7 +36,7 @@ describe("validateUniversalHandlerOptions()", function () {
       writeMaxBytes: 0xffffffff,
       jsonOptions: undefined,
       binaryOptions: undefined,
-      maxDeadlineDurationMs: Number.MAX_SAFE_INTEGER,
+      maxTimeoutMs: Number.MAX_SAFE_INTEGER,
       shutdownSignal: undefined,
       requireConnectProtocolHeader: false,
     });
@@ -60,7 +60,7 @@ describe("validateUniversalHandlerOptions()", function () {
         readUnknownFields: true,
         writeUnknownFields: false,
       },
-      maxDeadlineDurationMs: 888,
+      maxTimeoutMs: 888,
       shutdownSignal: new AbortController().signal,
       requireConnectProtocolHeader: true,
     };

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -86,8 +86,20 @@ export interface UniversalHandlerOptions {
    */
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  maxDeadlineDurationMs: number; // TODO TCN-785
-  shutdownSignal?: AbortSignal; // TODO TCN-919
+  /**
+   * The maximum value for timeouts that clients may specify.
+   * If a clients requests a timeout that is greater than maxTimeoutMs,
+   * the server responds with the error code InvalidArgument.
+   */
+  maxTimeoutMs: number;
+
+  /**
+   * To shut down servers gracefully, this option takes an AbortSignal.
+   * If this signal is aborted, all `deadline` AbortSignals in handler contexts
+   * will be aborted as well. This gives implementations a chance to wrap up
+   * work before the server process is killed.
+   */
+  shutdownSignal?: AbortSignal;
 
   /**
    * Require requests using the Connect protocol to include the header
@@ -158,8 +170,7 @@ export function validateUniversalHandlerOptions(
     : [];
   const requireConnectProtocolHeader =
     opt.requireConnectProtocolHeader ?? false;
-  const maxDeadlineDurationMs =
-    opt.maxDeadlineDurationMs ?? Number.MAX_SAFE_INTEGER;
+  const maxTimeoutMs = opt.maxTimeoutMs ?? Number.MAX_SAFE_INTEGER;
   return {
     acceptCompression,
     ...validateReadWriteMaxBytes(
@@ -169,7 +180,7 @@ export function validateUniversalHandlerOptions(
     ),
     jsonOptions: opt.jsonOptions,
     binaryOptions: opt.binaryOptions,
-    maxDeadlineDurationMs,
+    maxTimeoutMs,
     shutdownSignal: opt.shutdownSignal,
     requireConnectProtocolHeader,
   };


### PR DESCRIPTION
This PR adds support for timeouts on the server side for all three protocols. This feature from gRPC is also known as deadlines, and it can be used to limit the time a server may take to process a response.

For example, when a client provides the `timeoutMs` call option, a header `Connect-Timeout-Ms` is added to the request. The server parses this timeout, and if it takes longer than the given timeout to process the request, it should give up, and respond with the error code `deadline_exceeded`.

On a connect-es server, the parsed timeout is available as an `AbortSignal` on the context:

```ts
import type { HandlerContext } from "@bufbuild/connect";

const say = async (req: SayRequest, ctx: HandlerContext) => {

  ctx.deadline?.aborted; // true if timed out
  ctx.deadline?.reason; // an error with code deadline_exceed if timed out

  // raises an error with code deadline_exceed if timed out
  ctx.deadline?.throwIfAborted();

  // the AbortSignal can be passed to other functions
  await longRunning(ctx.deadline);

  return new SayResponse({sentence: `You said: ${req.sentence}`});
};
```

It is up to the implementation to honor the AbortSignal.

This also adds two related options to ConnectRouter:

```ts
  /**
   * The maximum value for timeouts that clients may specify.
   * If a clients requests a timeout that is greater than maxTimeoutMs,
   * the server responds with the error code InvalidArgument.
   */
  maxTimeoutMs: number;

  /**
   * To shut down servers gracefully, this option takes an AbortSignal.
   * If this signal is aborted, all `deadline` AbortSignals in handler contexts
   * will be aborted as well. This gives implementations a chance to wrap up
   * work before the server process is killed.
   */
  shutdownSignal?: AbortSignal;
```