### PR TITLE
Always generate files when no services exist

### DIFF
--- a/packages/protoc-gen-connect-es/src/declaration.ts
+++ b/packages/protoc-gen-connect-es/src/declaration.ts
@@ -23,9 +23,6 @@ import {
 
 export function generateDts(schema: Schema) {
   for (const protoFile of schema.files) {
-    if (protoFile.services.length == 0) {
-      continue;
-    }
     const file = schema.generateFile(protoFile.name + "_connect.d.ts");
     file.preamble(protoFile);
     for (const service of protoFile.services) {

--- a/packages/protoc-gen-connect-es/src/javascript.ts
+++ b/packages/protoc-gen-connect-es/src/javascript.ts
@@ -23,9 +23,6 @@ import {
 
 export function generateJs(schema: Schema) {
   for (const protoFile of schema.files) {
-    if (protoFile.services.length == 0) {
-      continue;
-    }
     const file = schema.generateFile(protoFile.name + "_connect.js");
     file.preamble(protoFile);
     for (const service of protoFile.services) {

--- a/packages/protoc-gen-connect-es/src/typescript.ts
+++ b/packages/protoc-gen-connect-es/src/typescript.ts
@@ -23,9 +23,6 @@ import {
 
 export function generateTs(schema: Schema) {
   for (const protoFile of schema.files) {
-    if (protoFile.services.length == 0) {
-      continue;
-    }
     const file = schema.generateFile(protoFile.name + "_connect.ts");
     file.preamble(protoFile);
     for (const service of protoFile.services) {


### PR DESCRIPTION
Previously, protoc-gen-connect-es would not emit a file when an input .proto file had no services declared within it. This unfortunately broke the keep_empty_files option, as there was never an empty file to keep. Ensure a file is always generated for each input file, allowing keep_empty_files to determine if it should remain before exiting.

fixes #597