### PR TITLE
Close the session on error in client transports

### DIFF
--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -132,8 +132,6 @@ export function createTestServers() {
             return;
           }
           nodeH2SecureServer.close((err) => (err ? reject(err) : resolve()));
-          // TODO this resolve is only there because we currently don't manage http2 sessions in the client, and the server doesn't shut down with an open connection
-          resolve(); // the server.close() callback above slows down our tests
         });
       },
     },
@@ -166,8 +164,6 @@ export function createTestServers() {
             return;
           }
           nodeH2cServer.close((err) => (err ? reject(err) : resolve()));
-          // TODO this resolve is only there because we currently don't manage http2 sessions in the client, and the server doesn't shut down with an open connection
-          resolve(); // the server.close() callback above slows down our tests
         });
       },
     },
@@ -287,12 +283,11 @@ export function createTestServers() {
         });
         await fastifyH2cServer.listen();
       },
-      stop() {
+      async stop() {
         if (!fastifyH2cServer) {
           throw new Error("fastifyH2cServer not started");
         }
-        void fastifyH2cServer.close(); // await close() slows down our tests
-        return Promise.resolve();
+        await fastifyH2cServer.close();
       },
     },
     // connect-express

--- a/packages/connect-node/src/node-transport-options.ts
+++ b/packages/connect-node/src/node-transport-options.ts
@@ -29,7 +29,7 @@ type CommonNodeTransportOptions = NodeHttpClientOptions &
  * Asserts that the options are within sane limits, and returns default values
  * where no value is provided.
  *
- * @internal
+ * @private Internal code, does not follow semantic versioning.
  */
 export function validateNodeTransportOptions(
   options: CommonNodeTransportOptions

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 107,197 b | 46,935 b | 12,539 b |
+| connect        | 107,175 b | 46,924 b | 12,556 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -1,0 +1,241 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
+import type {
+  UniversalClientRequest,
+  UniversalClientResponse,
+} from "../protocol/universal.js";
+import { createAsyncIterable } from "../protocol/async-iterable.js";
+import { ConnectError, connectErrorFromReason } from "../connect-error.js";
+import { createTransport } from "./transport.js";
+import { encodeEnvelope } from "../protocol/envelope.js";
+import { createEndStreamSerialization, endStreamFlag } from "./end-stream.js";
+import { Code } from "../code.js";
+import {
+  contentTypeStreamProto,
+  contentTypeUnaryProto,
+} from "./content-type.js";
+import type { Transport } from "../transport.js";
+import { errorToJsonBytes } from "./error-json.js";
+
+const TestService = {
+  typeName: "TestService",
+  methods: {
+    unary: {
+      name: "Unary",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.Unary,
+    },
+    server: {
+      name: "Server",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ServerStreaming,
+    },
+    client: {
+      name: "Client",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ClientStreaming,
+    },
+    biDi: {
+      name: "BiDi",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.BiDiStreaming,
+    },
+  },
+} as const;
+
+describe("Connect transport", function () {
+  const defaultOptions = {
+    baseUrl: "http://example.com",
+    interceptors: [],
+    acceptCompression: [],
+    compressMinBytes: 0,
+    readMaxBytes: 0xffffff,
+    sendCompression: null,
+    useBinaryFormat: true,
+    writeMaxBytes: 0xffffff,
+  };
+  describe("against server responding with unexpected content type", function () {
+    let httpRequestAborted = false;
+    let transport: Transport = null as unknown as Transport;
+    beforeEach(function () {
+      httpRequestAborted = false;
+      transport = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": "application/csv",
+            }),
+            body: createAsyncIterable([]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+    });
+    it("should cancel the HTTP request for unary", async function () {
+      try {
+        await transport.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+    it("should cancel the HTTP request for server-streaming", async function () {
+      try {
+        await transport.stream(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          createAsyncIterable([])
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+  });
+  describe("against server responding with an error", function () {
+    describe("for unary", function () {
+      let httpRequestAborted = false;
+      const t = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 429,
+            header: new Headers({
+              "Content-Type": contentTypeUnaryProto,
+            }),
+            body: createAsyncIterable([
+              errorToJsonBytes(
+                new ConnectError("foo", Code.ResourceExhausted),
+                {}
+              ),
+            ]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+      it("should cancel the HTTP request", async function () {
+        try {
+          await t.unary(
+            TestService,
+            TestService.methods.unary,
+            undefined,
+            undefined,
+            undefined,
+            {}
+          );
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] foo"
+          );
+        }
+        expect(httpRequestAborted).toBeTrue();
+      });
+    });
+    describe("for server-streaming", function () {
+      let httpRequestAborted = false;
+      const t = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": contentTypeStreamProto,
+            }),
+            body: createAsyncIterable([
+              encodeEnvelope(0, new StringValue({ value: "abc" }).toBinary()),
+              encodeEnvelope(
+                endStreamFlag,
+                createEndStreamSerialization({}).serialize({
+                  metadata: new Headers(),
+                  error: new ConnectError("foo", Code.ResourceExhausted),
+                })
+              ),
+            ]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+      it("should cancel the HTTP request", async function () {
+        const res = await t.stream(
+          TestService,
+          TestService.methods.server,
+          undefined,
+          undefined,
+          undefined,
+          createAsyncIterable([])
+        );
+        const messagesReceived: StringValue[] = [];
+        try {
+          for await (const m of res.message) {
+            messagesReceived.push(m);
+          }
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] foo"
+          );
+        }
+        expect(messagesReceived.length).toBe(1);
+        expect(httpRequestAborted).toBeTrue();
+      });
+    });
+  });
+});

--- a/packages/connect/src/protocol-connect/validate-response.spec.ts
+++ b/packages/connect/src/protocol-connect/validate-response.spec.ts
@@ -1,0 +1,86 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MethodKind } from "@bufbuild/protobuf";
+import { ConnectError, connectErrorFromReason } from "../connect-error.js";
+import { validateResponse } from "./validate-response.js";
+
+describe("validateResponse() Connect", function () {
+  it("should return unary error for HTTP error status", function () {
+    const r = validateResponse(
+      MethodKind.Unary,
+      false,
+      400,
+      new Headers({
+        "Content-Type": "application/proto",
+      })
+    );
+    expect(r.isUnaryError).toBeTrue();
+    expect(r.unaryError?.message).toBe("[invalid_argument] HTTP 400");
+  });
+  it("should throw error for content type application/csv", function () {
+    try {
+      validateResponse(
+        MethodKind.Unary,
+        false,
+        200,
+        new Headers({
+          "Content-Type": "application/csv",
+        })
+      );
+      fail("expected error");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConnectError);
+      expect(connectErrorFromReason(e).message).toBe(
+        '[invalid_argument] unexpected response content type "application/csv"'
+      );
+    }
+  });
+  it("should throw error for streaming content type for unary RPC", function () {
+    try {
+      validateResponse(
+        MethodKind.Unary,
+        false,
+        200,
+        new Headers({
+          "Content-Type": "application/connect+proto",
+        })
+      );
+      fail("expected error");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConnectError);
+      expect(connectErrorFromReason(e).message).toBe(
+        '[invalid_argument] unexpected response content type "application/connect+proto"'
+      );
+    }
+  });
+  it("should throw error for unary content type for streaming RPC", function () {
+    try {
+      validateResponse(
+        MethodKind.BiDiStreaming,
+        false,
+        200,
+        new Headers({
+          "Content-Type": "application/proto",
+        })
+      );
+      fail("expected error");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConnectError);
+      expect(connectErrorFromReason(e).message).toBe(
+        '[invalid_argument] unexpected response content type "application/proto"'
+      );
+    }
+  });
+});

--- a/packages/connect/src/protocol-connect/validate-response.ts
+++ b/packages/connect/src/protocol-connect/validate-response.ts
@@ -24,10 +24,9 @@ import { headerUnaryEncoding, headerStreamEncoding } from "./headers.js";
  * Validates response status and header for the Connect protocol.
  * Throws a ConnectError if the header indicates an error, or if
  * the content type is unexpected, with the following exception:
- * For unary RPCs with an HTTP error status and content type
- * application/json, this returns an error derived from the HTTP
- * status instead of throwing it, giving an implementation a chance
- * to parse a Connect error from the wire.
+ * For unary RPCs with an HTTP error status, this returns an error
+ * derived from the HTTP status instead of throwing it, giving an
+ * implementation a chance to parse a Connect error from the wire.
  *
  * @private Internal code, does not follow semantic versioning.
  */
@@ -46,12 +45,7 @@ export function validateResponse(
       `HTTP ${status}`,
       codeFromHttpStatus(status)
     );
-    if (
-      methodKind == MethodKind.Unary &&
-      parsedType &&
-      !parsedType.stream &&
-      !parsedType.binary
-    ) {
+    if (methodKind == MethodKind.Unary && parsedType && !parsedType.stream) {
       return { isUnaryError: true, unaryError: errorFromStatus };
     }
     throw errorFromStatus;

--- a/packages/connect/src/protocol-grpc-web/transport.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.spec.ts
@@ -1,0 +1,212 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
+import type { Transport } from "../transport.js";
+import { createTransport } from "./transport.js";
+import type {
+  UniversalClientRequest,
+  UniversalClientResponse,
+} from "../protocol/index.js";
+import { createAsyncIterable, encodeEnvelope } from "../protocol/index.js";
+import { ConnectError, connectErrorFromReason } from "../connect-error.js";
+import { Code } from "../code.js";
+import { trailerFlag, trailerSerialize } from "./trailer.js";
+
+const TestService = {
+  typeName: "TestService",
+  methods: {
+    unary: {
+      name: "Unary",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.Unary,
+    },
+    server: {
+      name: "Server",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ServerStreaming,
+    },
+    client: {
+      name: "Client",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ClientStreaming,
+    },
+    biDi: {
+      name: "BiDi",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.BiDiStreaming,
+    },
+  },
+} as const;
+
+describe("gRPC-web transport", function () {
+  const defaultOptions = {
+    baseUrl: "http://example.com",
+    interceptors: [],
+    acceptCompression: [],
+    compressMinBytes: 0,
+    readMaxBytes: 0xffffff,
+    sendCompression: null,
+    useBinaryFormat: true,
+    writeMaxBytes: 0xffffff,
+  };
+  describe("against server responding with unexpected content type", function () {
+    let httpRequestAborted = false;
+    let transport: Transport = null as unknown as Transport;
+    beforeEach(function () {
+      httpRequestAborted = false;
+      transport = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": "application/csv",
+            }),
+            body: createAsyncIterable([]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+    });
+    it("should cancel the HTTP request for unary", async function () {
+      try {
+        await transport.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+    it("should cancel the HTTP request for server-streaming", async function () {
+      try {
+        await transport.stream(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          createAsyncIterable([])
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+  });
+  describe("against server responding with an error", function () {
+    let httpRequestAborted = false;
+    let transport: Transport = null as unknown as Transport;
+    beforeEach(function () {
+      httpRequestAborted = false;
+      transport = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": "application/grpc-web+proto",
+            }),
+            body: createAsyncIterable([
+              encodeEnvelope(0, new StringValue({ value: "abc" }).toBinary()),
+              encodeEnvelope(
+                trailerFlag,
+                trailerSerialize(
+                  new Headers({
+                    "grpc-status": Code.ResourceExhausted.toString(),
+                    "grpc-message": "foo",
+                  })
+                )
+              ),
+            ]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+    });
+    it("should cancel the HTTP request for unary", async function () {
+      try {
+        await transport.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[resource_exhausted] foo"
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+    it("should cancel the HTTP request for server-streaming", async function () {
+      const res = await transport.stream(
+        TestService,
+        TestService.methods.server,
+        undefined,
+        undefined,
+        undefined,
+        createAsyncIterable([])
+      );
+      const messagesReceived: StringValue[] = [];
+      try {
+        for await (const m of res.message) {
+          messagesReceived.push(m);
+        }
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[resource_exhausted] foo"
+        );
+      }
+      expect(messagesReceived.length).toBe(1);
+      expect(httpRequestAborted).toBeTrue();
+    });
+  });
+});

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -19,7 +19,6 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import { Code, ConnectError, runStreaming, runUnary } from "../index.js";
 import type {
   StreamRequest,
   StreamResponse,
@@ -27,12 +26,16 @@ import type {
   UnaryRequest,
   UnaryResponse,
 } from "../index.js";
+import { Code, ConnectError, runStreaming, runUnary } from "../index.js";
+import type { CommonTransportOptions } from "../protocol/index.js";
 import {
   createAsyncIterable,
+  createLinkedAbortController,
   createMethodSerializationLookup,
   createMethodUrl,
   pipe,
   pipeTo,
+  transformCatchFinally,
   transformCompressEnvelope,
   transformDecompressEnvelope,
   transformJoinEnvelopes,
@@ -41,7 +44,6 @@ import {
   transformSerializeEnvelope,
   transformSplitEnvelope,
 } from "../protocol/index.js";
-import type { CommonTransportOptions } from "../protocol/index.js";
 import { validateTrailer } from "../protocol-grpc/validate-trailer.js";
 import { requestHeaderWithCompression } from "./request-header.js";
 import { validateResponseWithCompression } from "./validate-response.js";
@@ -69,6 +71,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
         opt.jsonOptions,
         opt
       );
+      const ac = createLinkedAbortController(signal);
       return await runUnary<I, O>(
         {
           stream: false,
@@ -85,7 +88,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
           ),
           message:
             message instanceof method.I ? message : new method.I(message),
-          signal: signal ?? new AbortController().signal,
+          signal: ac.signal,
         },
         async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
           const uRes = await opt.httpClient({
@@ -108,70 +111,78 @@ export function createTransport(opt: CommonTransportOptions): Transport {
               }
             ),
           });
-          const { compression } = validateResponseWithCompression(
-            opt.useBinaryFormat,
-            opt.acceptCompression,
-            uRes.status,
-            uRes.header
-          );
-          const { trailer, message } = await pipeTo(
-            uRes.body,
-            transformSplitEnvelope(opt.readMaxBytes),
-            transformDecompressEnvelope(compression ?? null, opt.readMaxBytes),
-            transformParseEnvelope<O, Headers>(
-              serialization.getO(opt.useBinaryFormat),
-              trailerFlag,
-              createTrailerSerialization()
-            ),
-            async (iterable) => {
-              let message: O | undefined;
-              let trailer: Headers | undefined;
-              for await (const env of iterable) {
-                if (env.end) {
-                  if (trailer !== undefined) {
-                    throw new ConnectError(
-                      "protocol error: received extra trailer",
-                      Code.InvalidArgument
-                    );
+          try {
+            const { compression } = validateResponseWithCompression(
+              opt.useBinaryFormat,
+              opt.acceptCompression,
+              uRes.status,
+              uRes.header
+            );
+            const { trailer, message } = await pipeTo(
+              uRes.body,
+              transformSplitEnvelope(opt.readMaxBytes),
+              transformDecompressEnvelope(
+                compression ?? null,
+                opt.readMaxBytes
+              ),
+              transformParseEnvelope<O, Headers>(
+                serialization.getO(opt.useBinaryFormat),
+                trailerFlag,
+                createTrailerSerialization()
+              ),
+              async (iterable) => {
+                let message: O | undefined;
+                let trailer: Headers | undefined;
+                for await (const env of iterable) {
+                  if (env.end) {
+                    if (trailer !== undefined) {
+                      throw new ConnectError(
+                        "protocol error: received extra trailer",
+                        Code.InvalidArgument
+                      );
+                    }
+                    trailer = env.value;
+                  } else {
+                    if (message !== undefined) {
+                      throw new ConnectError(
+                        "protocol error: received extra output message for unary method",
+                        Code.InvalidArgument
+                      );
+                    }
+                    message = env.value;
                   }
-                  trailer = env.value;
-                } else {
-                  if (message !== undefined) {
-                    throw new ConnectError(
-                      "protocol error: received extra output message for unary method",
-                      Code.InvalidArgument
-                    );
-                  }
-                  message = env.value;
                 }
+                return { trailer, message };
+              },
+              {
+                propagateDownStreamError: false,
               }
-              return { trailer, message };
-            },
-            {
-              propagateDownStreamError: false,
+            );
+            if (trailer === undefined) {
+              throw new ConnectError(
+                "protocol error: missing trailer",
+                Code.InvalidArgument
+              );
             }
-          );
-          if (trailer === undefined) {
-            throw new ConnectError(
-              "protocol error: missing trailer",
-              Code.InvalidArgument
-            );
+            validateTrailer(trailer);
+            if (message === undefined) {
+              throw new ConnectError(
+                "protocol error: missing output message for unary method",
+                Code.InvalidArgument
+              );
+            }
+            return <UnaryResponse<I, O>>{
+              stream: false,
+              service,
+              method,
+              header: uRes.header,
+              message,
+              trailer,
+            };
+          } catch (e) {
+            ac.abort(e);
+            throw e;
           }
-          validateTrailer(trailer);
-          if (message === undefined) {
-            throw new ConnectError(
-              "protocol error: missing output message for unary method",
-              Code.InvalidArgument
-            );
-          }
-          return <UnaryResponse<I, O>>{
-            stream: false,
-            service,
-            method,
-            header: uRes.header,
-            message,
-            trailer,
-          };
         },
         opt.interceptors
       );
@@ -193,6 +204,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
         opt.jsonOptions,
         opt
       );
+      const ac = createLinkedAbortController(signal);
       return runStreaming<I, O>(
         {
           stream: true,
@@ -204,7 +216,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             redirect: "error",
             mode: "cors",
           },
-          signal: signal ?? new AbortController().signal,
+          signal: ac.signal,
           header: requestHeaderWithCompression(
             opt.useBinaryFormat,
             timeoutMs,
@@ -236,82 +248,94 @@ export function createTransport(opt: CommonTransportOptions): Transport {
               { propagateDownStreamError: true }
             ),
           });
-          const { compression, foundStatus } = validateResponseWithCompression(
-            opt.useBinaryFormat,
-            opt.acceptCompression,
-            uRes.status,
-            uRes.header
-          );
-          const res: StreamResponse<I, O> = {
-            ...req,
-            header: uRes.header,
-            trailer: new Headers(),
-            message: pipe(
-              uRes.body,
-              transformSplitEnvelope(opt.readMaxBytes),
-              transformDecompressEnvelope(
-                compression ?? null,
-                opt.readMaxBytes
-              ),
-              transformParseEnvelope(
-                serialization.getO(opt.useBinaryFormat),
-                trailerFlag,
-                createTrailerSerialization()
-              ),
-              async function* (iterable) {
-                if (foundStatus) {
-                  // A grpc-status: 0 response header was present. This is a "trailers-only"
-                  // response (a response without a body and no trailers).
-                  //
-                  // The spec seems to disallow a trailers-only response for status 0 - we are
-                  // lenient and only verify that the body is empty.
-                  //
-                  // > [...] Trailers-Only is permitted for calls that produce an immediate error.
-                  // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
-                  const r = await iterable[Symbol.asyncIterator]().next();
-                  if (r.done !== true) {
-                    throw new ConnectError(
-                      "protocol error: extra data for trailers-only",
-                      Code.InvalidArgument
-                    );
-                  }
-                  return;
-                }
-                let trailerReceived = false;
-                for await (const chunk of iterable) {
-                  if (chunk.end) {
-                    if (trailerReceived) {
+          try {
+            const { compression, foundStatus } =
+              validateResponseWithCompression(
+                opt.useBinaryFormat,
+                opt.acceptCompression,
+                uRes.status,
+                uRes.header
+              );
+            const res: StreamResponse<I, O> = {
+              ...req,
+              header: uRes.header,
+              trailer: new Headers(),
+              message: pipe(
+                uRes.body,
+                transformSplitEnvelope(opt.readMaxBytes),
+                transformDecompressEnvelope(
+                  compression ?? null,
+                  opt.readMaxBytes
+                ),
+                transformParseEnvelope(
+                  serialization.getO(opt.useBinaryFormat),
+                  trailerFlag,
+                  createTrailerSerialization()
+                ),
+                async function* (iterable) {
+                  if (foundStatus) {
+                    // A grpc-status: 0 response header was present. This is a "trailers-only"
+                    // response (a response without a body and no trailers).
+                    //
+                    // The spec seems to disallow a trailers-only response for status 0 - we are
+                    // lenient and only verify that the body is empty.
+                    //
+                    // > [...] Trailers-Only is permitted for calls that produce an immediate error.
+                    // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+                    const r = await iterable[Symbol.asyncIterator]().next();
+                    if (r.done !== true) {
                       throw new ConnectError(
-                        "protocol error: received extra trailer",
+                        "protocol error: extra data for trailers-only",
                         Code.InvalidArgument
                       );
                     }
-                    trailerReceived = true;
-                    validateTrailer(chunk.value);
-                    chunk.value.forEach((value, key) =>
-                      res.trailer.set(key, value)
-                    );
-                    continue;
+                    return;
                   }
-                  if (trailerReceived) {
+                  let trailerReceived = false;
+                  for await (const chunk of iterable) {
+                    if (chunk.end) {
+                      if (trailerReceived) {
+                        throw new ConnectError(
+                          "protocol error: received extra trailer",
+                          Code.InvalidArgument
+                        );
+                      }
+                      trailerReceived = true;
+                      validateTrailer(chunk.value);
+                      chunk.value.forEach((value, key) =>
+                        res.trailer.set(key, value)
+                      );
+                      continue;
+                    }
+                    if (trailerReceived) {
+                      throw new ConnectError(
+                        "protocol error: received extra message after trailer",
+                        Code.InvalidArgument
+                      );
+                    }
+                    yield chunk.value;
+                  }
+                  if (!trailerReceived) {
                     throw new ConnectError(
-                      "protocol error: received extra message after trailer",
+                      "protocol error: missing trailer",
                       Code.InvalidArgument
                     );
                   }
-                  yield chunk.value;
-                }
-                if (!trailerReceived) {
-                  throw new ConnectError(
-                    "protocol error: missing trailer",
-                    Code.InvalidArgument
-                  );
-                }
-              },
-              { propagateDownStreamError: true }
-            ),
-          };
-          return res;
+                },
+                transformCatchFinally<O>((e): void => {
+                  if (e !== undefined) {
+                    ac.abort(e);
+                    throw e;
+                  }
+                }),
+                { propagateDownStreamError: true }
+              ),
+            };
+            return res;
+          } catch (e) {
+            ac.abort(e);
+            throw e;
+          }
         },
         opt.interceptors
       );

--- a/packages/connect/src/protocol-grpc-web/validate-response.ts
+++ b/packages/connect/src/protocol-grpc-web/validate-response.ts
@@ -54,8 +54,8 @@ export function validateResponse(
   const parsedType = parseContentType(mimeType);
   if (!parsedType || parsedType.binary != useBinaryFormat) {
     throw new ConnectError(
-      `unexpected response content type ${mimeType ?? "?"}`,
-      Code.Internal
+      `unexpected response content type "${mimeType ?? "?"}"`,
+      Code.InvalidArgument
     );
   }
   if (parsedType.text) {

--- a/packages/connect/src/protocol-grpc/transport.spec.ts
+++ b/packages/connect/src/protocol-grpc/transport.spec.ts
@@ -1,0 +1,207 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
+import type { Transport } from "../transport.js";
+import { createTransport } from "./transport.js";
+import type {
+  UniversalClientRequest,
+  UniversalClientResponse,
+} from "../protocol/index.js";
+import { createAsyncIterable, encodeEnvelope } from "../protocol/index.js";
+import { ConnectError, connectErrorFromReason } from "../connect-error.js";
+import { Code } from "../code.js";
+
+const TestService = {
+  typeName: "TestService",
+  methods: {
+    unary: {
+      name: "Unary",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.Unary,
+    },
+    server: {
+      name: "Server",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ServerStreaming,
+    },
+    client: {
+      name: "Client",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ClientStreaming,
+    },
+    biDi: {
+      name: "BiDi",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.BiDiStreaming,
+    },
+  },
+} as const;
+
+describe("gRPC transport", function () {
+  const defaultOptions = {
+    baseUrl: "http://example.com",
+    interceptors: [],
+    acceptCompression: [],
+    compressMinBytes: 0,
+    readMaxBytes: 0xffffff,
+    sendCompression: null,
+    useBinaryFormat: true,
+    writeMaxBytes: 0xffffff,
+  };
+  describe("against server responding with unexpected content type", function () {
+    let httpRequestAborted = false;
+    let transport: Transport = null as unknown as Transport;
+    beforeEach(function () {
+      httpRequestAborted = false;
+      transport = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": "application/csv",
+            }),
+            body: createAsyncIterable([]),
+            trailer: new Headers(),
+          });
+        },
+        ...defaultOptions,
+      });
+    });
+    it("should cancel the HTTP request for unary", async function () {
+      try {
+        await transport.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+    it("should cancel the HTTP request for server-streaming", async function () {
+      try {
+        await transport.stream(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          createAsyncIterable([])
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          '[invalid_argument] unexpected response content type "application/csv"'
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+  });
+  describe("against server responding with an error", function () {
+    let httpRequestAborted = false;
+    let transport: Transport = null as unknown as Transport;
+    beforeEach(function () {
+      httpRequestAborted = false;
+      transport = createTransport({
+        httpClient(
+          request: UniversalClientRequest
+        ): Promise<UniversalClientResponse> {
+          request.signal?.addEventListener(
+            "abort",
+            () => (httpRequestAborted = true)
+          );
+          return Promise.resolve({
+            status: 200,
+            header: new Headers({
+              "Content-Type": "application/grpc+proto",
+            }),
+            body: createAsyncIterable([
+              encodeEnvelope(0, new StringValue({ value: "abc" }).toBinary()),
+            ]),
+            trailer: new Headers({
+              "grpc-status": Code.ResourceExhausted.toString(),
+              "grpc-message": "foo",
+            }),
+          });
+        },
+        ...defaultOptions,
+      });
+    });
+
+    it("should cancel the HTTP request for unary", async function () {
+      try {
+        await transport.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[resource_exhausted] foo"
+        );
+      }
+      expect(httpRequestAborted).toBeTrue();
+    });
+
+    it("should cancel the HTTP request for server-streaming", async function () {
+      const res = await transport.stream(
+        TestService,
+        TestService.methods.server,
+        undefined,
+        undefined,
+        undefined,
+        createAsyncIterable([])
+      );
+      const messagesReceived: StringValue[] = [];
+      try {
+        for await (const m of res.message) {
+          messagesReceived.push(m);
+        }
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[resource_exhausted] foo"
+        );
+      }
+      expect(messagesReceived.length).toBe(1);
+      expect(httpRequestAborted).toBeTrue();
+    });
+  });
+});

--- a/packages/connect/src/protocol-grpc/validate-response.ts
+++ b/packages/connect/src/protocol-grpc/validate-response.ts
@@ -53,8 +53,8 @@ export function validateResponse(
   const parsedType = parseContentType(mimeType);
   if (!parsedType || parsedType.binary != useBinaryFormat) {
     throw new ConnectError(
-      `unexpected response content type ${mimeType ?? "?"}`,
-      Code.Internal
+      `unexpected response content type "${mimeType ?? "?"}"`,
+      Code.InvalidArgument
     );
   }
   const err = findTrailerError(headers);

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -87,6 +87,7 @@ export {
 } from "./invoke-implementation.js";
 export type { ParseDeadlineFn } from "./deadline-factory.js";
 export { createDeadlineParser } from "./deadline-factory.js";
+export { createLinkedAbortController } from "./linked-abort-controller.js";
 export {
   assertByteStreamRequest,
   uResponseOk,

--- a/packages/connect/src/protocol/linked-abort-controller.ts
+++ b/packages/connect/src/protocol/linked-abort-controller.ts
@@ -1,0 +1,56 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConnectError } from "../connect-error.js";
+import { Code } from "../code.js";
+
+/**
+ * Create an AbortController that is automatically aborted if one of the given
+ * signals is aborted.
+ *
+ * For convenience, the linked AbortSignals can be undefined.
+ *
+ * If the controller or any of the signals is aborted, all event listeners are
+ * removed.
+ *
+ * @private Internal code, does not follow semantic versioning.
+ */
+export function createLinkedAbortController(
+  ...signals: (AbortSignal | undefined)[]
+): AbortController {
+  const controller = new AbortController();
+
+  const sa = signals
+    .filter((s) => s !== undefined)
+    .concat(controller.signal) as AbortSignal[];
+
+  for (const signal of sa) {
+    signal.addEventListener("abort", onAbort);
+  }
+
+  function onAbort(this: AbortSignal) {
+    if (!controller.signal.aborted) {
+      // AbortSignal.reason was added in Node.js 17.2.0, we cannot rely on it.
+      controller.abort(
+        this.reason ??
+          new ConnectError("This operation was aborted", Code.Canceled)
+      );
+    }
+    for (const signal of sa) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  return controller;
+}


### PR DESCRIPTION
By default, we close HTTP/2 connections after each request in Node.js. 

But because of an oversight, the code handling the close never ran if we encountered an error, for example an unexpected response content type, or just an error encoded in the response body or response trailers of a streaming RPC.

