### PR TITLE
Indent "idempotency" in protoc-gen-connect-es

### DIFF
--- a/packages/connect-node-test/src/gen/grpc/testing/test_connect.ts
+++ b/packages/connect-node-test/src/gen/grpc/testing/test_connect.ts
@@ -91,7 +91,7 @@ export const TestService = {
       I: SimpleRequest,
       O: SimpleResponse,
       kind: MethodKind.Unary,
-    idempotency: MethodIdempotency.NoSideEffects,
+      idempotency: MethodIdempotency.NoSideEffects,
     },
     /**
      * One request followed by a sequence of responses (streamed download).

--- a/packages/connect-web-test/src/gen/grpc/testing/test_connect.ts
+++ b/packages/connect-web-test/src/gen/grpc/testing/test_connect.ts
@@ -91,7 +91,7 @@ export const TestService = {
       I: SimpleRequest,
       O: SimpleResponse,
       kind: MethodKind.Unary,
-    idempotency: MethodIdempotency.NoSideEffects,
+      idempotency: MethodIdempotency.NoSideEffects,
     },
     /**
      * One request followed by a sequence of responses (streamed download).

--- a/packages/protoc-gen-connect-es/src/typescript.ts
+++ b/packages/protoc-gen-connect-es/src/typescript.ts
@@ -58,7 +58,7 @@ function generateService(
     );
     if (method.idempotency !== undefined) {
       f.print(
-        "    idempotency: ",
+        "      idempotency: ",
         rtMethodIdempotency,
         ".",
         MethodIdempotency[method.idempotency],

--- a/packages/protoc-gen-connect-web/src/typescript.ts
+++ b/packages/protoc-gen-connect-web/src/typescript.ts
@@ -61,7 +61,7 @@ function generateService(
     );
     if (method.idempotency !== undefined) {
       f.print(
-        "    idempotency: ",
+        "      idempotency: ",
         rtMethodIdempotency,
         ".",
         MethodIdempotency[method.idempotency],


### PR DESCRIPTION
Our indentation is a bit off ([test.proto](https://github.com/bufbuild/connect-crosstest/blob/162d496c009e2ffb1a638b4a2ea789e9cc3331bb/internal/proto/grpc/testing/test.proto#L55)):

```ts
    cacheableUnaryCall: {
      name: "CacheableUnaryCall",
      I: SimpleRequest,
      O: SimpleResponse,
      kind: MethodKind.Unary,
    idempotency: MethodIdempotency.NoSideEffects,
    },
```

This adds two spaces to the TS output.