### PR TITLE
Raise proper Connect error codes for closed streams in handlers

### DIFF
--- a/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
+++ b/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
@@ -59,7 +59,6 @@ describe("cancel_after_begin", function () {
         expectError(e);
       }
     });
-    // TODO(TCN-679) consider extending callback clients for client- and bidi-streaming
   });
 
   afterAll(async () => await servers.stop());

--- a/packages/connect-node-test/src/crosstest/client_streaming.spec.ts
+++ b/packages/connect-node-test/src/crosstest/client_streaming.spec.ts
@@ -42,7 +42,6 @@ describe("client_streaming", () => {
       );
       expect(aggregatedPayloadSize).toBe(sizes.reduce((p, c) => p + c, 0));
     });
-    // TODO(TCN-679) consider extending callback clients for client- and bidi-streaming
   });
 
   afterAll(async () => await servers.stop());

--- a/packages/connect-node-test/src/crosstest/ping_pong.spec.ts
+++ b/packages/connect-node-test/src/crosstest/ping_pong.spec.ts
@@ -92,7 +92,6 @@ describe("ping_pong", () => {
         }
         expect(i).toBe(sizes.length);
       });
-      // TODO(TCN-679) consider extending callback clients for client- and bidi-streaming
     }
   );
 

--- a/packages/connect-node-test/src/crosstest/unresolvable_host.spec.ts
+++ b/packages/connect-node-test/src/crosstest/unresolvable_host.spec.ts
@@ -188,7 +188,6 @@ describe("unresolvable_host", function () {
             );
           });
         });
-        // TODO(TCN-679) consider extending callback clients for client- and bidi-streaming
       });
     });
   }

--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -384,7 +384,9 @@ describe("universal node http client", function () {
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
-          expect(connectErrorFromReason(e).message).toBe("[aborted] aborted");
+          expect(connectErrorFromReason(e).message).toMatch(
+            /\[aborted] (aborted|read ECONNRESET)/
+          );
         }
         expect(serverSentBytes).toBe(64);
       });

--- a/packages/connect-node/src/node-universal-handler.spec.ts
+++ b/packages/connect-node/src/node-universal-handler.spec.ts
@@ -1,0 +1,189 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useNodeServer } from "./use-node-server-helper.spec.js";
+import * as http2 from "http2";
+import * as http from "http";
+import { universalRequestFromNodeRequest } from "./node-universal-handler.js";
+import { ConnectError, connectErrorFromReason } from "@bufbuild/connect";
+import { readAllBytes } from "@bufbuild/connect/protocol";
+
+// Polyfill the Headers API for Node versions < 18
+import "./node-headers-polyfill.js";
+
+describe("universalRequestFromNodeRequest()", function () {
+  describe("with HTTP/2 stream closed with an RST code", function () {
+    let universalRequestSignal: AbortSignal | undefined;
+    const server = useNodeServer(() => {
+      universalRequestSignal = undefined;
+      return http2.createServer(function (request) {
+        universalRequestSignal = universalRequestFromNodeRequest(
+          request,
+          undefined
+        ).signal;
+      });
+    });
+    async function request(rstCode: number) {
+      await new Promise<void>((resolve) => {
+        http2.connect(server.getUrl(), (session: http2.ClientHttp2Session) => {
+          const stream = session.request(
+            {
+              ":method": "POST",
+              ":path": "/",
+            },
+            {}
+          );
+          setTimeout(() => {
+            stream.on("error", () => {
+              // Closing with _some_ codes raises an ERR_HTTP2_STREAM_ERROR
+              // error here.
+            });
+            stream.close(rstCode, () => {
+              // We are seeing a race condition in Node v16.20.0, where closing
+              // the session right after closing a stream with an RST code
+              // _sometimes_ sends an INTERNAL_ERROR code.
+              // Simply delaying the session close until the next tick like
+              // we do here seems to work around the issue.
+              setTimeout(() => session.close(resolve), 0);
+            });
+          }, 0);
+        });
+      });
+    }
+    it("should abort request signal with ConnectError and Code.Canceled for NO_ERROR", async function () {
+      await request(http2.constants.NGHTTP2_NO_ERROR);
+      expect(universalRequestSignal).toBeInstanceOf(AbortSignal);
+      expect(universalRequestSignal?.aborted).toBeTrue();
+      expect(universalRequestSignal?.reason).toBeInstanceOf(Error);
+      if (universalRequestSignal?.reason instanceof Error) {
+        expect(universalRequestSignal.reason.name).toBe("AbortError");
+        expect(universalRequestSignal.reason.message).toBe(
+          "This operation was aborted"
+        );
+      }
+    });
+    it("should abort request signal with ConnectError and Code.Canceled for CANCEL", async function () {
+      await request(http2.constants.NGHTTP2_CANCEL);
+      expect(universalRequestSignal).toBeInstanceOf(AbortSignal);
+      expect(universalRequestSignal?.aborted).toBeTrue();
+      expect(universalRequestSignal?.reason).toBeInstanceOf(ConnectError);
+      const ce = connectErrorFromReason(universalRequestSignal?.reason);
+      expect(ce.message).toBe(
+        "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+      );
+    });
+    it("should abort request signal with ConnectError and Code.ResourceExhausted for ENHANCE_YOUR_CALM", async function () {
+      await request(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
+      expect(universalRequestSignal).toBeInstanceOf(AbortSignal);
+      expect(universalRequestSignal?.aborted).toBeTrue();
+      expect(universalRequestSignal?.reason).toBeInstanceOf(ConnectError);
+      const ce = connectErrorFromReason(universalRequestSignal?.reason);
+      expect(ce.message).toBe(
+        "[resource_exhausted] http/2 stream closed with RST code ENHANCE_YOUR_CALM (0xb)"
+      );
+    });
+    it("should abort request signal with ConnectError and Code.Internal for FRAME_SIZE_ERROR", async function () {
+      await request(http2.constants.NGHTTP2_FRAME_SIZE_ERROR);
+      expect(universalRequestSignal).toBeInstanceOf(AbortSignal);
+      expect(universalRequestSignal?.aborted).toBeTrue();
+      expect(universalRequestSignal?.reason).toBeInstanceOf(ConnectError);
+      const ce = connectErrorFromReason(universalRequestSignal?.reason);
+      expect(ce.message).toBe(
+        "[internal] http/2 stream closed with RST code FRAME_SIZE_ERROR (0x6)"
+      );
+    });
+  });
+  describe("with HTTP/1.1 ECONNRESET", function () {
+    let serverAbortReason: undefined | unknown;
+    const server = useNodeServer(() =>
+      http.createServer(
+        {
+          connectionsCheckingInterval: 1,
+        },
+        function (request) {
+          const uReq = universalRequestFromNodeRequest(request, undefined);
+          uReq.signal.addEventListener("abort", () => {
+            serverAbortReason = uReq.signal.reason;
+          });
+        }
+      )
+    );
+    it("should abort request signal with ConnectError and Code.Aborted", async function () {
+      await new Promise<void>((resolve) => {
+        const request = http.request(server.getUrl(), {
+          method: "POST",
+        });
+        request.on("error", () => {
+          // we need this event lister so that Node.js does not raise the error
+          // we trigger by calling destroy()
+        });
+        request.flushHeaders();
+        setTimeout(() => {
+          request.destroy();
+          resolve();
+        }, 20);
+      });
+      while (serverAbortReason === undefined) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      expect(serverAbortReason).toBeInstanceOf(Error);
+      if (serverAbortReason instanceof Error) {
+        expect(serverAbortReason).toBeInstanceOf(ConnectError);
+        const ce = connectErrorFromReason(serverAbortReason);
+        expect(ce.message).toBe("[aborted] aborted");
+      }
+    });
+  });
+  describe("with HTTP/1.1 request finishing without error", function () {
+    let universalRequestSignal: AbortSignal | undefined;
+    const server = useNodeServer(() =>
+      http.createServer(
+        {
+          connectionsCheckingInterval: 1,
+        },
+        function (request, response) {
+          const uReq = universalRequestFromNodeRequest(request, undefined);
+          universalRequestSignal = uReq.signal;
+          response.writeHead(200);
+          response.end();
+        }
+      )
+    );
+    it("should abort request signal with AbortError", async function () {
+      await new Promise<void>((resolve) => {
+        const request = http.request(server.getUrl(), {
+          method: "POST",
+          // close TCP connection after we're done so that the server shuts down cleanly
+          agent: new http.Agent({ keepAlive: false }),
+        });
+        request.flushHeaders();
+        request.end();
+        request.on("response", (response) => {
+          void readAllBytes(response, Number.MAX_SAFE_INTEGER).then(() =>
+            resolve()
+          );
+        });
+      });
+      expect(universalRequestSignal).toBeInstanceOf(AbortSignal);
+      expect(universalRequestSignal?.aborted).toBeTrue();
+      expect(universalRequestSignal?.reason).toBeInstanceOf(Error);
+      if (universalRequestSignal?.reason instanceof Error) {
+        expect(universalRequestSignal.reason.name).toBe("AbortError");
+        expect(universalRequestSignal.reason.message).toBe(
+          "This operation was aborted"
+        );
+      }
+    });
+  });
+});

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -95,7 +95,7 @@ export function universalRequestFromNodeRequest(
   const abortController = new AbortController();
   if ("stream" in nodeRequest) {
     // HTTP/2 has error codes we want to honor
-    nodeRequest.on("close", () => {
+    nodeRequest.once("close", () => {
       const err = connectErrorFromH2ResetCode(nodeRequest.stream.rstCode);
       if (err !== undefined) {
         abortController.abort(err);
@@ -104,8 +104,19 @@ export function universalRequestFromNodeRequest(
       }
     });
   } else {
-    // HTTP/1.1 does not
-    nodeRequest.on("close", () => abortController.abort());
+    // HTTP/1.1 does not have error codes, but Node.js has ECONNRESET
+    const onH1Error = (e: Error) => {
+      nodeRequest.off("error", onH1Error);
+      nodeRequest.off("close", onH1Close);
+      abortController.abort(connectErrorFromNodeReason(e));
+    };
+    const onH1Close = () => {
+      nodeRequest.off("error", onH1Error);
+      nodeRequest.off("close", onH1Close);
+      abortController.abort();
+    };
+    nodeRequest.once("error", onH1Error);
+    nodeRequest.once("close", onH1Close);
   }
   return {
     httpVersion: nodeRequest.httpVersion,

--- a/packages/connect-node/src/use-node-server-helper.spec.ts
+++ b/packages/connect-node/src/use-node-server-helper.spec.ts
@@ -30,14 +30,14 @@ export function useNodeServer(
     | http2.Http2SecureServer
     | undefined;
 
-  beforeAll(function (doneFn) {
+  beforeEach(function (doneFn) {
     server = createServer();
     server.listen(0, function listenCallback() {
       doneFn();
     });
   });
 
-  afterAll(async function () {
+  afterEach(async function () {
     if (server === undefined) {
       throw new Error("server not defined");
     }

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -24,7 +24,7 @@ import type {
 } from "@bufbuild/protobuf";
 import { ConnectError } from "./connect-error.js";
 import { Code } from "./code.js";
-import { createLinkedAbortController } from "./protocol/linked-abort-controller.js";
+import { createLinkedAbortController } from "./protocol/index.js";
 
 // prettier-ignore
 /**

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -172,7 +172,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
           setTrailerStatus(
             context.responseTrailer,
             new ConnectError(
-              "internal error" + String(e),
+              "internal error",
               Code.Internal,
               undefined,
               undefined,

--- a/packages/connect/src/protocol/deadline-factory.ts
+++ b/packages/connect/src/protocol/deadline-factory.ts
@@ -101,7 +101,6 @@ export function createDeadlineSignal(
       );
     }
   }
-  polyfillThrowIfAborted(controller.signal, shutdownSignal);
   return {
     signal: controller.signal,
     cleanup: () => cleanups.map((fn) => fn()),
@@ -120,24 +119,4 @@ function errShutdown(cause?: unknown) {
     undefined,
     cause
   );
-}
-
-// Polyfill missing throwIfAborted for Node.js < 17.3.0.
-function polyfillThrowIfAborted(
-  signal: AbortSignal,
-  shutdownSignal: AbortSignal | undefined
-) {
-  if ("throwIfAborted" in signal) {
-    return;
-  }
-  const s = signal as AbortSignal;
-  s.throwIfAborted = function () {
-    if (s.aborted) {
-      // AbortSignal.reason was added in Node.js 17.2.0, we cannot rely on it either.
-      throw (
-        s.reason ??
-        (shutdownSignal?.aborted === true ? errShutdown() : errTimeout())
-      );
-    }
-  };
 }

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -87,7 +87,10 @@ export {
 } from "./invoke-implementation.js";
 export type { ParseDeadlineFn } from "./deadline-factory.js";
 export { createDeadlineParser } from "./deadline-factory.js";
-export { createLinkedAbortController } from "./linked-abort-controller.js";
+export {
+  createLinkedAbortController,
+  getAbortSignalReason,
+} from "./signals.js";
 export {
   assertByteStreamRequest,
   uResponseOk,


### PR DESCRIPTION
This PR follows up on https://github.com/bufbuild/connect-es/pull/531 and adds more test coverage.

We are making sure that we always trigger the AbortSignal in the HandlerContext when a request is finished, and that the abort reason has the proper Connect error code on Node.js. 

This includes the mapping of HTTP/2 REST_STREAM codes to Connect error codes, so that requests canceled on the client trigger the signal of the HandlerContext with Code.Canceled. 
