### PR TITLE
Add createRouterTransport() to the connect-node-test crosstests

### DIFF
--- a/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
+++ b/packages/connect-node-test/src/crosstest/cancel_after_begin.spec.ts
@@ -28,38 +28,44 @@ describe("cancel_after_begin", function () {
     }
   }
 
-  servers.describeTransports((transport) => {
-    const servers = createTestServers();
-    beforeAll(async () => await servers.start());
-    it("with promise client", async function () {
-      const client = createPromiseClient(TestService, transport());
-      const controller = new AbortController();
-      async function* input() {
-        yield {
-          payload: {
-            body: new Uint8Array(),
-            type: PayloadType.COMPRESSABLE,
-          },
-        };
-        await new Promise((resolve) => setTimeout(resolve, 1));
-        controller.abort();
-        yield {
-          payload: {
-            body: new Uint8Array(),
-            type: PayloadType.COMPRESSABLE,
-          },
-        };
-      }
-      try {
-        await client.streamingInputCall(input(), {
-          signal: controller.signal,
-        });
-        fail("expected error");
-      } catch (e) {
-        expectError(e);
-      }
-    });
-  });
+  servers.describeTransportsExcluding(
+    [
+      "@bufbuild/connect (ConnectRouter, binary)",
+      "@bufbuild/connect (ConnectRouter, JSON)",
+    ],
+    (transport) => {
+      const servers = createTestServers();
+      beforeAll(async () => await servers.start());
+      it("with promise client", async function () {
+        const client = createPromiseClient(TestService, transport());
+        const controller = new AbortController();
+        async function* input() {
+          yield {
+            payload: {
+              body: new Uint8Array(),
+              type: PayloadType.COMPRESSABLE,
+            },
+          };
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          controller.abort();
+          yield {
+            payload: {
+              body: new Uint8Array(),
+              type: PayloadType.COMPRESSABLE,
+            },
+          };
+        }
+        try {
+          await client.streamingInputCall(input(), {
+            signal: controller.signal,
+          });
+          fail("expected error");
+        } catch (e) {
+          expectError(e);
+        }
+      });
+    }
+  );
 
   afterAll(async () => await servers.stop());
 });

--- a/packages/connect-node-test/src/crosstest/unresolvable_host.spec.ts
+++ b/packages/connect-node-test/src/crosstest/unresolvable_host.spec.ts
@@ -15,11 +15,9 @@
 import {
   Code,
   ConnectError,
-  type ConnectRouter,
   connectErrorFromReason,
   createCallbackClient,
   createPromiseClient,
-  createRouterTransport,
 } from "@bufbuild/connect";
 import {
   createConnectTransport,
@@ -41,20 +39,6 @@ describe("unresolvable_host", function () {
     ...baseOptions,
     httpVersion: "1.1" as const,
   };
-  const unresolvableRouter = ({ service }: ConnectRouter) => {
-    const unavailableRoute = () => {
-      throw new ConnectError(
-        "getaddrinfo ENOTFOUND unresolvable-host.some.domain",
-        Code.Unavailable
-      );
-    };
-    service(TestService, {
-      streamingOutputCall: unavailableRoute,
-      unaryCall: unavailableRoute,
-      streamingInputCall: unavailableRoute,
-      fullDuplexCall: unavailableRoute,
-    });
-  };
   const transports = [
     [
       "@bufbuild/connect-node (gRPC-web, http2)",
@@ -74,10 +58,6 @@ describe("unresolvable_host", function () {
     ],
     ["@bufbuild/connect-node (gRPC, http2)", createGrpcTransport(optionsHttp2)],
     ["@bufbuild/connect-node (gRPC, http)", createGrpcTransport(optionsHttp1)],
-    [
-      "@bufbuild/connect (ConnectRouter)",
-      createRouterTransport(unresolvableRouter, { transport: baseOptions }),
-    ],
   ] as const;
   for (const [name, transport] of transports) {
     describe(`${name} against unresolvable domain`, function () {

--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -17,7 +17,7 @@ import * as http from "http";
 import * as https from "https";
 import * as fs from "fs";
 import * as path from "path";
-import type { Transport } from "@bufbuild/connect";
+import { createRouterTransport, type Transport } from "@bufbuild/connect";
 import { cors } from "@bufbuild/connect";
 import {
   compressionGzip,
@@ -772,7 +772,7 @@ export function createTestServers() {
           sendCompression: compressionGzip,
         }),
 
-    //gRPC-web
+    // gRPC-web
     "@bufbuild/connect-node (gRPC-web, binary, http2) against @bufbuild/connect-node (h2c)":
       (options?: Record<string, unknown>) =>
         createGrpcWebTransport({
@@ -993,7 +993,27 @@ export function createTestServers() {
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
-  } as const;
+
+    // ConnectRouter
+    "@bufbuild/connect (ConnectRouter, binary)": (
+      options?: Record<string, unknown>
+    ) =>
+      createRouterTransport(testRoutes, {
+        transport: {
+          ...options,
+          useBinaryFormat: true,
+        },
+      }),
+    "@bufbuild/connect (ConnectRouter, JSON)": (
+      options?: Record<string, unknown>
+    ) =>
+      createRouterTransport(testRoutes, {
+        transport: {
+          ...options,
+          useBinaryFormat: false,
+        },
+      }),
+  };
 
   return {
     servers,

--- a/packages/connect-node-test/src/node-readme.spec.ts
+++ b/packages/connect-node-test/src/node-readme.spec.ts
@@ -72,7 +72,10 @@ describe("node readme", function () {
 
   it("createConnectTransport()", async function () {
     // A transport for clients using the gRPC protocol with Node.js `http` module
-    const transport = createConnectTransport(optionsHttp1);
+    const transport = createConnectTransport({
+      baseUrl: "https://demo.connect.build",
+      httpVersion: "1.1" as const,
+    });
     const client = createPromiseClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();

--- a/packages/connect-node-test/src/node-readme.spec.ts
+++ b/packages/connect-node-test/src/node-readme.spec.ts
@@ -22,6 +22,7 @@ import {
   createGrpcWebTransport,
   createConnectTransport,
 } from "@bufbuild/connect-node";
+import { createRouterTransport } from "@bufbuild/connect";
 
 /* eslint-disable @typescript-eslint/require-await */
 
@@ -60,12 +61,18 @@ describe("node readme", function () {
     },
   } as const;
 
+  const optionsHttp2 = {
+    baseUrl: "https://demo.connect.build",
+    httpVersion: "2" as const,
+  };
+  const optionsHttp1 = {
+    baseUrl: "https://demo.connect.build",
+    httpVersion: "1.1" as const,
+  };
+
   it("createConnectTransport()", async function () {
     // A transport for clients using the gRPC protocol with Node.js `http` module
-    const transport = createConnectTransport({
-      baseUrl: "https://demo.connect.build",
-      httpVersion: "1.1",
-    });
+    const transport = createConnectTransport(optionsHttp1);
     const client = createPromiseClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
@@ -73,10 +80,7 @@ describe("node readme", function () {
 
   it("createGrpcTransport()", async function () {
     // A transport for clients using the gRPC protocol with Node.js `http2` module
-    const transport = createGrpcTransport({
-      baseUrl: "https://demo.connect.build",
-      httpVersion: "2",
-    });
+    const transport = createGrpcTransport(optionsHttp2);
     const client = createPromiseClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
@@ -84,10 +88,26 @@ describe("node readme", function () {
 
   it("createGrpcWebTransport()", async function () {
     // A transport for clients using the gRPC-web protocol with Node.js `http` module
-    const transport = createGrpcWebTransport({
-      baseUrl: "https://demo.connect.build",
-      httpVersion: "1.1",
-    });
+    const transport = createGrpcWebTransport(optionsHttp1);
+    const client = createPromiseClient(ElizaService, transport);
+    const { sentence } = await client.say({ sentence: "I feel happy." });
+    expect(sentence).toBeDefined();
+  });
+
+  it("createRouterTransport()", async function () {
+    // A transport for clients using the in-memory createRouterTransport
+    const transport = createRouterTransport(
+      ({ service }) => {
+        service(ElizaService, {
+          say: async () => ({
+            sentence: "server response",
+          }),
+        });
+      },
+      {
+        transport: optionsHttp1,
+      }
+    );
     const client = createPromiseClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();

--- a/packages/connect-node-test/src/node-readme.spec.ts
+++ b/packages/connect-node-test/src/node-readme.spec.ts
@@ -74,7 +74,7 @@ describe("node readme", function () {
     // A transport for clients using the gRPC protocol with Node.js `http` module
     const transport = createConnectTransport({
       baseUrl: "https://demo.connect.build",
-      httpVersion: "1.1" as const,
+      httpVersion: "1.1",
     });
     const client = createPromiseClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });


### PR DESCRIPTION
I want to make sure this is moving in the right direction, so I've only done `connect-node-test` and will follow up with `connect-web-test` if this is correct.

We don't have good coverage for createRouterTransport() yet, but we really want to be certain that it behaves like other transports that use the network. We can use the crosstests for this.

The crosstest are, a schema and a set of tests defined in bufbuild/connect-crosstest. We have two implementations in the connect-es repository:
- connect-node-test: runs the Connect, gRPC, and gRPC-web transports with various options from @bufbuild/connect node against various servers
- connect-web-test: runs the Connect and gRPC-web transports from @bufbuild/connect-web with various options against various servers, in a headless web browser, on Node.js, optionally in a local web browser, and against several browsers and devices on browserstack (in CI).

We are also about to add connect-edge-test, for using the same pattern for code running in edge environments.

Ideally, we would add a router transport to all three test packages, so that we have confidence that it behaves as expected in all environments.