### PR TITLE
Support timeouts in clients

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 109,228 b | 47,812 b | 12,800 b |
+| connect        | 111,637 b | 49,004 b | 13,163 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -51,7 +51,7 @@ export { cors } from "./cors.js";
 
 // Symbols above should be relevant to end users.
 // Symbols below should only be relevant for other libraries.
-export { runUnary, runStreaming } from "./interceptor.js";
+export { runUnary, runStreaming } from "./legacy-interceptor.js";
 export { makeAnyClient } from "./any-client.js";
 export type { AnyClient } from "./any-client.js";
 

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -55,30 +55,6 @@ type AnyFn = (
 ) => Promise<UnaryResponse | StreamResponse>;
 
 /**
- * UnaryFn represents the client-side invocation of a unary RPC - a method
- * that takes a single input message, and responds with a single output
- * message.
- * A Transport implements such a function, and makes it available to
- * interceptors.
- */
-type UnaryFn<
-  I extends Message<I> = AnyMessage,
-  O extends Message<O> = AnyMessage
-> = (req: UnaryRequest<I, O>) => Promise<UnaryResponse<I, O>>;
-
-/**
- * StreamingFn represents the client-side invocation of a streaming RPC - a
- * method that takes zero or more input messages, and responds with zero or
- * more output messages.
- * A Transport implements such a function, and makes it available to
- * interceptors.
- */
-type StreamingFn<
-  I extends Message<I> = AnyMessage,
-  O extends Message<O> = AnyMessage
-> = (req: StreamRequest<I, O>) => Promise<StreamResponse<I, O>>;
-
-/**
  * UnaryRequest is used in interceptors to represent a request with a
  * single input message.
  */
@@ -212,50 +188,4 @@ interface ResponseCommon<I extends Message<I>, O extends Message<O>> {
    * has been read.
    */
   readonly trailer: Headers;
-}
-
-/**
- * applyInterceptors takes the given UnaryFn or ServerStreamingFn, and wraps
- * it with each of the given interceptors, returning a new UnaryFn or
- * ServerStreamingFn.
- */
-function applyInterceptors<T>(next: T, interceptors: Interceptor[]): T {
-  return interceptors
-    .concat()
-    .reverse()
-    .reduce(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      (n, i) => i(n),
-      next as any // eslint-disable-line @typescript-eslint/no-explicit-any
-    ) as T;
-}
-
-/**
- * Runs a unary method with the given interceptors. Note that this function
- * is only used when implementing a Transport.
- */
-export function runUnary<I extends Message<I>, O extends Message<O>>(
-  req: UnaryRequest<I, O>,
-  next: UnaryFn<I, O>,
-  interceptors: Interceptor[] | undefined
-): Promise<UnaryResponse<I, O>> {
-  if (interceptors) {
-    next = applyInterceptors(next, interceptors);
-  }
-  return next(req);
-}
-
-/**
- * Runs a server-streaming method with the given interceptors. Note that this
- * function is only used when implementing a Transport.
- */
-export function runStreaming<I extends Message<I>, O extends Message<O>>(
-  req: StreamRequest<I, O>,
-  next: StreamingFn<I, O>,
-  interceptors: Interceptor[] | undefined
-): Promise<StreamResponse<I, O>> {
-  if (interceptors) {
-    next = applyInterceptors(next, interceptors);
-  }
-  return next(req);
 }

--- a/packages/connect/src/legacy-interceptor.ts
+++ b/packages/connect/src/legacy-interceptor.ts
@@ -1,0 +1,96 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { AnyMessage, Message } from "@bufbuild/protobuf";
+import type {
+  Interceptor,
+  StreamRequest,
+  StreamResponse,
+  UnaryRequest,
+  UnaryResponse,
+} from "./interceptor.js";
+
+/**
+ * Runs a unary method with the given interceptors. Note that this function
+ * is only used when implementing a Transport.
+ *
+ * @deprecated Use runUnaryCall from @bufbuild/connect/protocol instead.
+ */
+export function runUnary<I extends Message<I>, O extends Message<O>>(
+  req: UnaryRequest<I, O>,
+  next: UnaryFn<I, O>,
+  interceptors: Interceptor[] | undefined
+): Promise<UnaryResponse<I, O>> {
+  if (interceptors) {
+    next = applyInterceptors(next, interceptors);
+  }
+  return next(req);
+}
+
+/**
+ * Runs a server-streaming method with the given interceptors. Note that this
+ * function is only used when implementing a Transport.
+ *
+ * @deprecated Use runStreamingCall from @bufbuild/connect/protocol instead.
+ */
+export function runStreaming<I extends Message<I>, O extends Message<O>>(
+  req: StreamRequest<I, O>,
+  next: StreamingFn<I, O>,
+  interceptors: Interceptor[] | undefined
+): Promise<StreamResponse<I, O>> {
+  if (interceptors) {
+    next = applyInterceptors(next, interceptors);
+  }
+  return next(req);
+}
+
+/**
+ * applyInterceptors takes the given UnaryFn or ServerStreamingFn, and wraps
+ * it with each of the given interceptors, returning a new UnaryFn or
+ * ServerStreamingFn.
+ */
+function applyInterceptors<T>(next: T, interceptors: Interceptor[]): T {
+  return interceptors
+    .concat()
+    .reverse()
+    .reduce(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      (n, i) => i(n),
+      next as any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ) as T;
+}
+
+/**
+ * UnaryFn represents the client-side invocation of a unary RPC - a method
+ * that takes a single input message, and responds with a single output
+ * message.
+ * A Transport implements such a function, and makes it available to
+ * interceptors.
+ */
+type UnaryFn<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage
+> = (req: UnaryRequest<I, O>) => Promise<UnaryResponse<I, O>>;
+
+/**
+ * StreamingFn represents the client-side invocation of a streaming RPC - a
+ * method that takes zero or more input messages, and responds with zero or
+ * more output messages.
+ * A Transport implements such a function, and makes it available to
+ * interceptors.
+ */
+type StreamingFn<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage
+> = (req: StreamRequest<I, O>) => Promise<StreamResponse<I, O>>;

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -25,6 +25,7 @@ export type { Compression } from "./compression.js";
 export type { UniversalHandler } from "./universal-handler.js";
 export { createUniversalHandlerClient } from "./universal-handler-client.js";
 export { createFetchClient, createFetchHandler } from "./universal-fetch.js";
+export { runUnaryCall, runStreamingCall } from "./run-call.js";
 
 // All exports below are private — internal code that does not follow semantic
 // versioning.

--- a/packages/connect/src/protocol/run-call.spec.ts
+++ b/packages/connect/src/protocol/run-call.spec.ts
@@ -1,0 +1,223 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Int32Value,
+  MethodKind,
+  type ServiceType,
+  StringValue,
+} from "@bufbuild/protobuf";
+import { runStreamingCall, runUnaryCall } from "./run-call.js";
+import type {
+  StreamRequest,
+  StreamResponse,
+  UnaryRequest,
+  UnaryResponse,
+} from "../interceptor.js";
+import { createAsyncIterable } from "./async-iterable.js";
+
+const TestService = {
+  typeName: "TestService",
+  methods: {
+    unary: {
+      name: "Unary",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.Unary,
+    },
+    serverStreaming: {
+      name: "ServerStreaming",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ServerStreaming,
+    },
+  },
+} satisfies ServiceType;
+
+describe("runUnaryCall()", function () {
+  function makeReq() {
+    return {
+      stream: false as const,
+      service: TestService,
+      method: TestService.methods.unary,
+      url: `https://example.com/TestService/Unary`,
+      init: {},
+      header: new Headers(),
+      message: new Int32Value({ value: 123 }),
+    };
+  }
+
+  function makeRes(req: UnaryRequest<Int32Value, StringValue>) {
+    return <UnaryResponse<Int32Value, StringValue>>{
+      stream: false,
+      service: TestService,
+      method: TestService.methods.unary,
+      header: new Headers(),
+      message: new StringValue({ value: req.message.value.toString(10) }),
+      trailer: new Headers(),
+    };
+  }
+  it("should return the response", async function () {
+    const res = await runUnaryCall<Int32Value, StringValue>({
+      timeoutMs: undefined,
+      signal: undefined,
+      interceptors: [],
+      req: makeReq(),
+      async next(req) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return makeRes(req);
+      },
+    });
+    expect(res.message.value).toBe("123");
+  });
+  it("should trigger the signal when done", async function () {
+    let signal: AbortSignal | undefined;
+    await runUnaryCall<Int32Value, StringValue>({
+      req: makeReq(),
+      async next(req) {
+        signal = req.signal;
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return makeRes(req);
+      },
+    });
+    expect(signal?.aborted).toBeTrue();
+  });
+  it("should raise Code.Canceled on user abort", async function () {
+    const userAbort = new AbortController();
+    const resPromise = runUnaryCall<Int32Value, StringValue>({
+      signal: userAbort.signal,
+      req: makeReq(),
+      async next(req) {
+        for (;;) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          req.signal.throwIfAborted();
+        }
+      },
+    });
+    userAbort.abort();
+    await expectAsync(resPromise).toBeRejectedWithError(
+      "[canceled] This operation was aborted"
+    );
+  });
+  it("should raise Code.DeadlineExceeded on timeout", async function () {
+    const resPromise = runUnaryCall<Int32Value, StringValue>({
+      timeoutMs: 1,
+      req: makeReq(),
+      async next(req) {
+        for (;;) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          req.signal.throwIfAborted();
+        }
+      },
+    });
+    await expectAsync(resPromise).toBeRejectedWithError(
+      "[deadline_exceeded] the operation timed out"
+    );
+  });
+});
+
+describe("runStreamingCall()", function () {
+  function makeReq() {
+    return {
+      stream: true as const,
+      service: TestService,
+      method: TestService.methods.serverStreaming,
+      url: `https://example.com/TestService/ServerStreaming`,
+      init: {},
+      header: new Headers(),
+      message: createAsyncIterable([new Int32Value({ value: 123 })]),
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function makeRes(req: StreamRequest<Int32Value, StringValue>) {
+    return <StreamResponse<Int32Value, StringValue>>{
+      stream: true,
+      service: TestService,
+      method: TestService.methods.serverStreaming,
+      header: new Headers(),
+      message: createAsyncIterable([
+        new StringValue({ value: "1" }),
+        new StringValue({ value: "2" }),
+        new StringValue({ value: "3" }),
+      ]),
+      trailer: new Headers(),
+    };
+  }
+
+  it("should return the response", async function () {
+    const res = await runStreamingCall<Int32Value, StringValue>({
+      timeoutMs: undefined,
+      signal: undefined,
+      interceptors: [],
+      req: makeReq(),
+      async next(req) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return makeRes(req);
+      },
+    });
+    const values: string[] = [];
+    for await (const m of res.message) {
+      values.push(m.value);
+    }
+    expect(values).toEqual(["1", "2", "3"]);
+  });
+  it("should trigger the signal when done", async function () {
+    let signal: AbortSignal | undefined;
+    const res = await runStreamingCall<Int32Value, StringValue>({
+      req: makeReq(),
+      async next(req) {
+        signal = req.signal;
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return makeRes(req);
+      },
+    });
+    for await (const m of res.message) {
+      expect(m).toBeDefined();
+    }
+    expect(signal?.aborted).toBeTrue();
+  });
+  it("should raise Code.Canceled on user abort", async function () {
+    const userAbort = new AbortController();
+    const resPromise = runStreamingCall<Int32Value, StringValue>({
+      signal: userAbort.signal,
+      req: makeReq(),
+      async next(req) {
+        for (;;) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          req.signal.throwIfAborted();
+        }
+      },
+    });
+    userAbort.abort();
+    await expectAsync(resPromise).toBeRejectedWithError(
+      "[canceled] This operation was aborted"
+    );
+  });
+  it("should raise Code.DeadlineExceeded on timeout", async function () {
+    const resPromise = runStreamingCall<Int32Value, StringValue>({
+      timeoutMs: 1,
+      req: makeReq(),
+      async next(req) {
+        for (;;) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          req.signal.throwIfAborted();
+        }
+      },
+    });
+    await expectAsync(resPromise).toBeRejectedWithError(
+      "[deadline_exceeded] the operation timed out"
+    );
+  });
+});

--- a/packages/connect/src/protocol/run-call.ts
+++ b/packages/connect/src/protocol/run-call.ts
@@ -1,0 +1,186 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { AnyMessage, Message } from "@bufbuild/protobuf";
+import type {
+  Interceptor,
+  StreamRequest,
+  StreamResponse,
+  UnaryRequest,
+  UnaryResponse,
+} from "../interceptor.js";
+import { connectErrorFromReason } from "../connect-error.js";
+import {
+  createDeadlineSignal,
+  createLinkedAbortController,
+  getAbortSignalReason,
+} from "./signals.js";
+
+/**
+ * UnaryFn represents the client-side invocation of a unary RPC - a method
+ * that takes a single input message, and responds with a single output
+ * message.
+ * A Transport implements such a function, and makes it available to
+ * interceptors.
+ */
+type UnaryFn<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage
+> = (req: UnaryRequest<I, O>) => Promise<UnaryResponse<I, O>>;
+
+/**
+ * Runs a unary method with the given interceptors. Note that this function
+ * is only used when implementing a Transport.
+ */
+export function runUnaryCall<I extends Message<I>, O extends Message<O>>(opt: {
+  req: Omit<UnaryRequest<I, O>, "signal">;
+  next: UnaryFn<I, O>;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  interceptors?: Interceptor[];
+}): Promise<UnaryResponse<I, O>> {
+  const next = applyInterceptors(opt.next, opt.interceptors);
+  const [signal, abort, done] = setupSignal(opt);
+  const req = {
+    ...opt.req,
+    signal,
+  };
+  return next(req).then((res) => {
+    done();
+    return res;
+  }, abort);
+}
+
+/**
+ * StreamingFn represents the client-side invocation of a streaming RPC - a
+ * method that takes zero or more input messages, and responds with zero or
+ * more output messages.
+ * A Transport implements such a function, and makes it available to
+ * interceptors.
+ */
+type StreamingFn<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage
+> = (req: StreamRequest<I, O>) => Promise<StreamResponse<I, O>>;
+
+/**
+ * Runs a server-streaming method with the given interceptors. Note that this
+ * function is only used when implementing a Transport.
+ */
+export function runStreamingCall<
+  I extends Message<I>,
+  O extends Message<O>
+>(opt: {
+  req: Omit<StreamRequest<I, O>, "signal">;
+  next: StreamingFn<I, O>;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  interceptors?: Interceptor[];
+}): Promise<StreamResponse<I, O>> {
+  const next = applyInterceptors(opt.next, opt.interceptors);
+  const [signal, abort, done] = setupSignal(opt);
+  const req = {
+    ...opt.req,
+    signal,
+  };
+  return next(req).then((res) => {
+    return {
+      ...res,
+      message: {
+        [Symbol.asyncIterator]() {
+          const it = res.message[Symbol.asyncIterator]();
+          const w: AsyncIterator<O> = {
+            next() {
+              return it.next().then((r) => {
+                if (r.done == true) {
+                  done();
+                }
+                return r;
+              }, abort);
+            },
+          };
+          if (it.throw !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- can't handle mutated object sensibly
+            w.throw = (e: unknown) => it.throw!(e);
+          }
+          if (it.return !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-explicit-any -- can't handle mutated object sensibly
+            w.return = (value?: any) => it.return!(value);
+          }
+          return w;
+        },
+      },
+    };
+  }, abort);
+}
+
+/**
+ * Create an AbortSignal for Transport implementations. The signal is available
+ * in UnaryRequest and StreamingRequest, and is triggered when the call is
+ * aborted (via a timeout or explicit cancellation), errored (e.g. when reading
+ * an error from the server from the wire), or finished successfully.
+ *
+ * Transport implementations can pass the signal to HTTP clients to ensure that
+ * there are no unused connections leak.
+ *
+ * Returns a tuple:
+ * [0]: The signal, which is also aborted if the optional deadline is reached.
+ * [1]: Function to call if the Transport encountered an error.
+ * [2]: Function to call if the Transport finished without an error.
+ */
+function setupSignal(opt: {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): [AbortSignal, (reason: unknown) => Promise<never>, () => void] {
+  const { signal, cleanup } = createDeadlineSignal(opt.timeoutMs);
+  const controller = createLinkedAbortController(opt.signal, signal);
+  return [
+    controller.signal,
+    function abort(reason: unknown): Promise<never> {
+      // We peek at the deadline signal because fetch() will throw an error on
+      // abort that discards the signal reason.
+      const e = connectErrorFromReason(
+        signal.aborted ? getAbortSignalReason(signal) : reason
+      );
+      controller.abort(e);
+      cleanup();
+      return Promise.reject(e);
+    },
+    function done() {
+      cleanup();
+      controller.abort();
+    },
+  ];
+}
+
+/**
+ * applyInterceptors takes the given UnaryFn or ServerStreamingFn, and wraps
+ * it with each of the given interceptors, returning a new UnaryFn or
+ * ServerStreamingFn.
+ */
+function applyInterceptors<T>(
+  next: T,
+  interceptors: Interceptor[] | undefined
+): T {
+  return (
+    (interceptors
+      ?.concat()
+      .reverse()
+      .reduce(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        (n, i) => i(n),
+        next as any // eslint-disable-line @typescript-eslint/no-explicit-any
+      ) as T) ?? next
+  );
+}

--- a/packages/connect/src/protocol/signals.spec.ts
+++ b/packages/connect/src/protocol/signals.spec.ts
@@ -66,6 +66,12 @@ describe("createDeadlineSignal()", function () {
       expect(d.signal.aborted).toBeTrue();
     });
   });
+  describe("with -1 timeout", function () {
+    it("should be aborted immediately", function () {
+      const d = createDeadlineSignal(-1);
+      expect(d.signal.aborted).toBeTrue();
+    });
+  });
   describe("with undefined timeout", function () {
     it("should still return a signal", function () {
       const d = createDeadlineSignal(undefined);

--- a/packages/connect/src/protocol/signals.ts
+++ b/packages/connect/src/protocol/signals.ts
@@ -70,15 +70,15 @@ export function createDeadlineSignal(timeoutMs: number | undefined): {
   cleanup: () => void;
 } {
   const controller = new AbortController();
-  const listener = () =>
+  const listener = () => {
     controller.abort(
       new ConnectError("the operation timed out", Code.DeadlineExceeded)
     );
+  };
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  if (timeoutMs === 0) {
-    listener();
-  } else if (timeoutMs !== undefined) {
-    timeoutId = setTimeout(listener, timeoutMs);
+  if (timeoutMs !== undefined) {
+    if (timeoutMs <= 0) listener();
+    else timeoutId = setTimeout(listener, timeoutMs);
   }
   return {
     signal: controller.signal,


### PR DESCRIPTION
In https://github.com/bufbuild/connect-es/pull/591, we added support for timeouts in handlers. For better reliability, timeouts are now honored in clients as well. 

For example, consider the following client call:

```ts
elizaClient.say({ sentence: "Hello" }, { timeoutMs: 2500 });
```

The timeout of 2.5 seconds is sent to the server in a request header (this works for the gRPC, gRPC-web, and for the Connect protocol). If the timeout is reached before the server could produce a response in time, it will send an error with Code.DeadlineExceeded instead. 

But if this error does not reach the client (for example because a connection became unresponsive), the client would wait for a response well past the timeout. With this PR, the timeout is not just sent as a header, but it is also honored in the client. If no response arrives before the timeout, the client will raise an error with Code.DeadlineExceeded itself, and stop the request.

The logic is implemented in the functions `runUnaryCall` and `runStreamingCall` from `@bufbuild/connect/protocol`, so that Transport implementations do not have to care about this detail themselves. 

The old versions of the functions - `runUnary` and `runStreaming` from `@bufbuild/connect` - are now marked deprecated.