### PR TITLE
Clean up universal request / response types

### DIFF
--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -77,7 +77,6 @@ describe("universal node http client", function () {
               url: "https://unresolvable-host.some.domain",
               method: "POST",
               header: new Headers(),
-              body: createAsyncIterable([]),
             });
           } catch (e) {
             expect(ConnectError.from(e).message).toBe(
@@ -108,7 +107,6 @@ describe("universal node http client", function () {
             url: server.getUrl(),
             method: "POST",
             header: new Headers(),
-            body: createAsyncIterable([]),
           });
           fail("expected error");
         } catch (e) {
@@ -137,7 +135,6 @@ describe("universal node http client", function () {
             url: server.getUrl(),
             method: "POST",
             header: new Headers(),
-            body: createAsyncIterable([]),
           });
           fail("expected error");
         } catch (e) {
@@ -169,7 +166,6 @@ describe("universal node http client", function () {
           url: server.getUrl(),
           method: "POST",
           header: new Headers(),
-          body: createAsyncIterable([]),
         });
         try {
           for await (const chunk of res.body) {
@@ -203,7 +199,6 @@ describe("universal node http client", function () {
           url: server.getUrl(),
           method: "POST",
           header: new Headers(),
-          body: createAsyncIterable([]),
         });
         try {
           for await (const chunk of res.body) {
@@ -332,7 +327,6 @@ describe("universal node http client", function () {
           url: server.getUrl(),
           method: "POST",
           header: new Headers(),
-          body: createAsyncIterable([]),
         });
         try {
           for await (const chunk of res.body) {
@@ -371,7 +365,6 @@ describe("universal node http client", function () {
           url: server.getUrl(),
           method: "POST",
           header: new Headers(),
-          body: createAsyncIterable([]),
         });
         try {
           for await (const chunk of res.body) {
@@ -408,7 +401,6 @@ describe("universal node http client", function () {
             url: server.getUrl(),
             method: "POST",
             header: new Headers(),
-            body: createAsyncIterable([]),
             signal,
           });
           fail("expected error");
@@ -438,7 +430,6 @@ describe("universal node http client", function () {
             url: server.getUrl(),
             method: "POST",
             header: new Headers(),
-            body: createAsyncIterable([]),
             signal,
           });
           fail("expected error");

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -136,7 +136,7 @@ function createNodeHttp1Client(
           method: req.method,
         },
         (request) => {
-          pipeTo(req.body, sinkRequest(sentinel, request), {
+          void pipeTo(req.body, sinkRequest(sentinel, request), {
             propagateDownStreamError: true,
           }).catch(sentinel.reject);
           request.on("response", (response) => {

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -139,13 +139,7 @@ export async function universalResponseToNodeResponse(
   nodeResponse: NodeServerResponse
 ): Promise<void> {
   try {
-    if (universalResponse.body instanceof Uint8Array) {
-      nodeResponse.writeHead(
-        universalResponse.status,
-        webHeaderToNodeHeaders(universalResponse.header)
-      );
-      await write(nodeResponse, universalResponse.body);
-    } else if (universalResponse.body !== undefined) {
+    if (universalResponse.body !== undefined) {
       for await (const chunk of universalResponse.body) {
         // we deliberately send headers *in* this loop, not before,
         // because we have to give the implementation a chance to

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -178,7 +178,6 @@ export async function universalResponseToNodeResponse(
       nodeResponse.addTrailers(
         webHeaderToNodeHeaders(universalResponse.trailer)
       );
-      universalResponse.trailer;
     }
     await new Promise<void>((resolve) => {
       // The npm package "compression" crashes when a callback is passed to end()

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -121,7 +121,7 @@ export function universalRequestFromNodeRequest(
   return {
     httpVersion: nodeRequest.httpVersion,
     method: nodeRequest.method ?? "",
-    url: new URL(pathname, `${protocol}://${authority}`),
+    url: new URL(pathname, `${protocol}://${authority}`).toString(),
     header: nodeHeaderToWebHeader(nodeRequest.headers),
     body,
     signal: abortController.signal,

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -169,7 +169,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "1.1",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({ "Content-Type": "application/json" }),
           body: 777,
           signal: new AbortController().signal,
@@ -193,7 +193,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "1.1",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({
             "Content-Type": "application/json",
             "Connect-Protocol-Version": "UNEXPECTED",
@@ -230,7 +230,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "1.1",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({ "Content-Type": "application/connect+json" }),
           body: createAsyncIterable([new Uint8Array()]),
           signal: new AbortController().signal,
@@ -251,7 +251,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "1.1",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({
             "Content-Type": "application/connect+json",
             "Connect-Protocol-Version": "UNEXPECTED",
@@ -290,9 +290,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "2.0",
           method: "POST",
-          url: new URL(
-            `https://example.com/${service.typeName}/${method.name}`
-          ),
+          url: `https://example.com/${service.typeName}/${method.name}`,
           header: requestHeader(method.kind, true, timeoutMs, undefined),
           body: createAsyncIterable([new Uint8Array(0)]),
           signal: new AbortController().signal,
@@ -347,9 +345,7 @@ describe("createHandlerFactory()", function () {
         const res = await handler({
           httpVersion: "2.0",
           method: "POST",
-          url: new URL(
-            `https://example.com/${service.typeName}/${method.name}`
-          ),
+          url: `https://example.com/${service.typeName}/${method.name}`,
           header: requestHeader(method.kind, true, timeoutMs, undefined),
           body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
           signal: new AbortController().signal,
@@ -389,9 +385,7 @@ describe("createHandlerFactory()", function () {
         const resPromise = handler({
           httpVersion: "2.0",
           method: "POST",
-          url: new URL(
-            `https://example.com/${service.typeName}/${method.name}`
-          ),
+          url: `https://example.com/${service.typeName}/${method.name}`,
           header: requestHeader(method.kind, true, undefined, undefined),
           body: createAsyncIterable([new Uint8Array(0)]),
           signal: ac.signal,
@@ -422,9 +416,7 @@ describe("createHandlerFactory()", function () {
         const resPromise = handler({
           httpVersion: "2.0",
           method: "POST",
-          url: new URL(
-            `https://example.com/${service.typeName}/${method.name}`
-          ),
+          url: `https://example.com/${service.typeName}/${method.name}`,
           header: requestHeader(method.kind, true, undefined, undefined),
           body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
           signal: ac.signal,
@@ -453,9 +445,7 @@ describe("createHandlerFactory()", function () {
       const res = await handler({
         httpVersion: "2.0",
         method: "GET",
-        url: new URL(
-          `https://example.com/${service.typeName}/${method.name}?connect=v1&encoding=proto&base64=1&message=CHs`
-        ),
+        url: `https://example.com/${service.typeName}/${method.name}?connect=v1&encoding=proto&base64=1&message=CHs`,
         header: new Headers(),
         body: createAsyncIterable([]),
         signal: new AbortController().signal,

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -40,6 +40,7 @@ import { errorFromJsonBytes } from "./error-json.js";
 import { endStreamFromJson } from "./end-stream.js";
 import { createTransport } from "./transport.js";
 import { requestHeader } from "./request-header.js";
+import { readAll } from "../protocol/async-iterable-helper.spec.js";
 
 describe("createHandlerFactory()", function () {
   const testService = {
@@ -174,10 +175,12 @@ describe("createHandlerFactory()", function () {
           signal: new AbortController().signal,
         });
         expect(res.status).toBe(400);
-        expect(res.body).toBeInstanceOf(Uint8Array);
-        if (res.body instanceof Uint8Array) {
+        expect(res.body).toBeDefined();
+        if (res.body !== undefined) {
+          const body = await readAll(res.body);
+          expect(body.length).toBe(1);
           const err = errorFromJsonBytes(
-            res.body,
+            body[0],
             undefined,
             new ConnectError("failed to parse connect err", Code.Internal)
           );
@@ -199,10 +202,12 @@ describe("createHandlerFactory()", function () {
           signal: new AbortController().signal,
         });
         expect(res.status).toBe(400);
-        expect(res.body).toBeInstanceOf(Uint8Array);
-        if (res.body instanceof Uint8Array) {
+        expect(res.body).toBeDefined();
+        if (res.body !== undefined) {
+          const body = await readAll(res.body);
+          expect(body.length).toBe(1);
           const err = errorFromJsonBytes(
-            res.body,
+            body[0],
             undefined,
             new ConnectError("failed to parse connect err", Code.Internal)
           );

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -38,6 +38,7 @@ import {
   assertByteStreamRequest,
   compressionNegotiate,
   contentTypeMatcher,
+  createAsyncIterable,
   createMethodSerializationLookup,
   createMethodUrl,
   invokeUnaryImplementation,
@@ -268,7 +269,7 @@ function createUnaryHandler<I extends Message<I>, O extends Message<O>>(
     header.set(headerUnaryContentLength, body.byteLength.toString(10));
     return {
       status,
-      body,
+      body: createAsyncIterable([body]),
       header,
     };
   };

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -162,7 +162,7 @@ function createUnaryHandler<I extends Message<I>, O extends Message<O>>(
     if (isGet && spec.method.idempotency != MethodIdempotency.NoSideEffects) {
       return uResponseMethodNotAllowed;
     }
-    const queryParams = req.url.searchParams;
+    const queryParams = new URL(req.url).searchParams;
     const compressionRequested = isGet
       ? queryParams.get(paramCompression)
       : req.header.get(headerUnaryEncoding);

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -260,6 +260,7 @@ describe("Connect transport", function () {
       body: createAsyncIterable([new StringValue({ value: "abc" }).toBinary()]),
       trailer: new Headers(),
     };
+    // eslint-disable-next-line @typescript-eslint/require-await
     const expectGet: UniversalClientFn = async (request) => {
       expect(request.method).toBe("GET");
       expect(request.url).toBe(
@@ -270,15 +271,17 @@ describe("Connect transport", function () {
       request.header.forEach((_, key) => headerFields.push(key));
       expect(headerFields).toEqual([]);
       // no body
-      const body = await readAllBytes(request.body, Number.MAX_SAFE_INTEGER);
-      expect(body.byteLength).toBe(0);
+      expect(request.body).toBeUndefined();
       return httpClientResponse;
     };
     const expectPost: UniversalClientFn = async (request) => {
       expect(request.method).toBe("POST");
       expect(new URL(request.url).search).toBe("");
-      const body = await readAllBytes(request.body, Number.MAX_SAFE_INTEGER);
-      expect(body.byteLength).toBeGreaterThan(0);
+      expect(request.body).toBeDefined();
+      if (request.body !== undefined) {
+        const body = await readAllBytes(request.body, Number.MAX_SAFE_INTEGER);
+        expect(body.byteLength).toBeGreaterThan(0);
+      }
       return httpClientResponse;
     };
     describe("disabled", function () {

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -113,14 +113,13 @@ export function createTransport(opt: CommonTransportOptions): Transport {
           const useGet =
             opt.useHttpGet === true &&
             method.idempotency === MethodIdempotency.NoSideEffects;
-          let body: AsyncIterable<Uint8Array>;
+          let body: AsyncIterable<Uint8Array> | undefined;
           if (useGet) {
             req = transformConnectPostToGetRequest(
               req,
               requestBody,
               opt.useBinaryFormat
             );
-            body = createAsyncIterable([]);
           } else {
             body = createAsyncIterable([requestBody]);
           }

--- a/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
@@ -140,7 +140,7 @@ describe("createHandlerFactory()", function () {
       await handler({
         httpVersion: "2.0",
         method: "POST",
-        url: new URL(`https://example.com/${service.typeName}/${method.name}`),
+        url: `https://example.com/${service.typeName}/${method.name}`,
         header: requestHeader(true, timeoutMs, undefined),
         body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
         signal: new AbortController().signal,
@@ -172,7 +172,7 @@ describe("createHandlerFactory()", function () {
       const resPromise = handler({
         httpVersion: "2.0",
         method: "POST",
-        url: new URL(`https://example.com/${service.typeName}/${method.name}`),
+        url: `https://example.com/${service.typeName}/${method.name}`,
         header: requestHeader(true, undefined, undefined),
         body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
         signal: ac.signal,

--- a/packages/connect/src/protocol-grpc/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.spec.ts
@@ -140,7 +140,7 @@ describe("createHandlerFactory()", function () {
       await handler({
         httpVersion: "2.0",
         method: "POST",
-        url: new URL(`https://example.com/${service.typeName}/${method.name}`),
+        url: `https://example.com/${service.typeName}/${method.name}`,
         header: requestHeader(true, timeoutMs, undefined),
         body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
         signal: new AbortController().signal,
@@ -172,7 +172,7 @@ describe("createHandlerFactory()", function () {
       const resPromise = handler({
         httpVersion: "2.0",
         method: "POST",
-        url: new URL(`https://example.com/${service.typeName}/${method.name}`),
+        url: `https://example.com/${service.typeName}/${method.name}`,
         header: requestHeader(true, undefined, undefined),
         body: createAsyncIterable([encodeEnvelope(0, new Uint8Array(0))]),
         signal: ac.signal,

--- a/packages/connect/src/protocol/universal-fetch.ts
+++ b/packages/connect/src/protocol/universal-fetch.ts
@@ -84,11 +84,10 @@ function universalServerRequestFromFetch(
   req: Request,
   options: FetchHandlerOptions
 ): UniversalServerRequest {
-  const url = new URL(req.url);
   return {
     httpVersion: options.httpVersion ?? "",
     method: req.method,
-    url,
+    url: req.url,
     header: req.headers,
     body: iterableFromReadableStream(req.body),
     signal: req.signal,

--- a/packages/connect/src/protocol/universal-fetch.ts
+++ b/packages/connect/src/protocol/universal-fetch.ts
@@ -61,11 +61,13 @@ export function createFetchHandler(
 }
 
 function universalClientRequestToFetch(req: UniversalClientRequest): Request {
+  const body =
+    req.body === undefined ? null : iterableToReadableStream(req.body);
   return new Request(req.url, {
     method: req.method,
     headers: req.header,
     signal: req.signal,
-    body: iterableToReadableStream(req.body),
+    body,
   });
 }
 

--- a/packages/connect/src/protocol/universal-fetch.ts
+++ b/packages/connect/src/protocol/universal-fetch.ts
@@ -98,10 +98,8 @@ function universalServerRequestFromFetch(
 function universalServerResponseToFetch(
   res: UniversalServerResponse
 ): Response {
-  let body: ReadableStream<Uint8Array> | Uint8Array | null = null;
-  if (res.body instanceof Uint8Array) {
-    body = res.body;
-  } else if (res.body !== undefined) {
+  let body: ReadableStream<Uint8Array> | null = null;
+  if (res.body !== undefined) {
     body = iterableToReadableStream(res.body);
   }
   return new Response(body, {

--- a/packages/connect/src/protocol/universal-handler-client.ts
+++ b/packages/connect/src/protocol/universal-handler-client.ts
@@ -43,7 +43,7 @@ export function createUniversalHandlerClient(
     const uServerRes = await raceSignal(
       reqSignal,
       handler({
-        body: uClientReq.body,
+        body: uClientReq.body ?? createAsyncIterable([]),
         httpVersion: "2.0",
         method: uClientReq.method,
         url: uClientReq.url,

--- a/packages/connect/src/protocol/universal-handler-client.ts
+++ b/packages/connect/src/protocol/universal-handler-client.ts
@@ -31,11 +31,11 @@ export function createUniversalHandlerClient(
     handlerMap.set(handler.requestPath, handler);
   }
   return async (uClientReq) => {
-    const reqUrl = new URL(uClientReq.url);
-    const handler = handlerMap.get(reqUrl.pathname);
+    const pathname = new URL(uClientReq.url).pathname;
+    const handler = handlerMap.get(pathname);
     if (!handler) {
       throw new ConnectError(
-        `RouterHttpClient: no handler registered for ${reqUrl.pathname}`,
+        `RouterHttpClient: no handler registered for ${pathname}`,
         Code.Unimplemented
       );
     }
@@ -46,7 +46,7 @@ export function createUniversalHandlerClient(
         body: uClientReq.body,
         httpVersion: "2.0",
         method: uClientReq.method,
-        url: reqUrl,
+        url: uClientReq.url,
         header: uClientReq.header,
         signal: reqSignal,
       })

--- a/packages/connect/src/protocol/universal-handler.spec.ts
+++ b/packages/connect/src/protocol/universal-handler.spec.ts
@@ -152,7 +152,7 @@ describe("negotiateProtocol()", function () {
       const r = await h({
         httpVersion: "1.1",
         method: "POST",
-        url: new URL("https://example.com"),
+        url: "https://example.com",
         header: new Headers({ "Content-Type": "UNSUPPORTED" }),
         body: null,
         signal: new AbortController().signal,
@@ -163,7 +163,7 @@ describe("negotiateProtocol()", function () {
       const r = await h({
         httpVersion: "1.1",
         method: "UNSUPPORTED",
-        url: new URL("https://example.com"),
+        url: "https://example.com",
         header: new Headers({ "Content-Type": "application/x" }),
         body: null,
         signal: new AbortController().signal,
@@ -174,7 +174,7 @@ describe("negotiateProtocol()", function () {
       const r = await h({
         httpVersion: "1.1",
         method: "POST",
-        url: new URL("https://example.com"),
+        url: "https://example.com",
         header: new Headers({ "Content-Type": "application/x" }),
         body: null,
         signal: new AbortController().signal,
@@ -186,7 +186,7 @@ describe("negotiateProtocol()", function () {
       const r = await h({
         httpVersion: "1.1",
         method: "POST",
-        url: new URL("https://example.com"),
+        url: "https://example.com",
         header: new Headers(),
         body: null,
         signal: new AbortController().signal,
@@ -208,7 +208,7 @@ describe("negotiateProtocol()", function () {
         const r = await h({
           httpVersion: "1.1",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({ "Content-Type": "application/x" }),
           body: null,
           signal: new AbortController().signal,
@@ -221,7 +221,7 @@ describe("negotiateProtocol()", function () {
         const r = await h({
           httpVersion: "2",
           method: "POST",
-          url: new URL("https://example.com"),
+          url: "https://example.com",
           header: new Headers({ "Content-Type": "application/x" }),
           body: null,
           signal: new AbortController().signal,

--- a/packages/connect/src/protocol/universal.ts
+++ b/packages/connect/src/protocol/universal.ts
@@ -28,7 +28,7 @@ export interface UniversalClientRequest {
   url: string;
   method: string;
   header: Headers;
-  body: AsyncIterable<Uint8Array>;
+  body?: AsyncIterable<Uint8Array>;
   signal?: AbortSignal;
 }
 

--- a/packages/connect/src/protocol/universal.ts
+++ b/packages/connect/src/protocol/universal.ts
@@ -54,7 +54,7 @@ export type UniversalHandlerFn = (
  */
 export interface UniversalServerRequest {
   httpVersion: string;
-  url: URL;
+  url: string;
   method: string;
   header: Headers;
   /**

--- a/packages/connect/src/protocol/universal.ts
+++ b/packages/connect/src/protocol/universal.ts
@@ -54,8 +54,8 @@ export type UniversalHandlerFn = (
  */
 export interface UniversalServerRequest {
   httpVersion: string;
-  method: string;
   url: URL;
+  method: string;
   header: Headers;
   /**
    * Many server frameworks parse request bodies with the mime type
@@ -73,7 +73,7 @@ export interface UniversalServerRequest {
 export interface UniversalServerResponse {
   status: number;
   header?: Headers;
-  body?: AsyncIterable<Uint8Array> | Uint8Array;
+  body?: AsyncIterable<Uint8Array>;
   trailer?: Headers;
 }
 


### PR DESCRIPTION
This PR is a breaking change to the universal request and response types, with the intention to get a bit more consistency and simplicity for the long run.

The `body` property of `UniversalClientRequest` is made optional, for a better fit for GET requests:

```diff
interface UniversalClientRequest {
  url: string;
  method: string;
  header: Headers;
- body: AsyncIterable<Uint8Array>;
+ body?: AsyncIterable<Uint8Array>;
  signal?: AbortSignal;
}
```

The `url` property of `UniversalServerRequest` becomes a simple string, for consistency with client requests:

```diff
interface UniversalServerRequest {
  httpVersion: string;
+ url: string;
- url: URL;
  method: string;
  header: Headers;
  body: AsyncIterable<Uint8Array> | JsonValue;
  signal: AbortSignal;
}
```

The `body` property of `UniversalServerResponse` can no longer be a single `Uint8Array`, for consistency with other bodies.

```diff
interface UniversalServerResponse {
  status: number;
  header?: Headers;
+ body?: AsyncIterable<Uint8Array>;
- body?: AsyncIterable<Uint8Array> | Uint8Array;
  trailer?: Headers;
}
```

It would be great if we could make `body` optional in `UniversalClientResponse` and `UniversalServerRequest`, but it would complicate the Node.js implementation. But with this change, we can make sure to only set a body for a fetch request when we mean to, and the other direction is handled by us.

It would be fantastic if we could remove `JsonValue` from `UniversalServerRequest`, but as long as Next.js parses `application/json` on it's own, we have to keep supporting it.