### PR TITLE
Add tests for maxTimeoutMs

### DIFF
--- a/packages/connect/src/protocol/universal-handler-client.ts
+++ b/packages/connect/src/protocol/universal-handler-client.ts
@@ -51,10 +51,7 @@ export function createUniversalHandlerClient(
         signal: reqSignal,
       })
     );
-    let body = uServerRes.body ?? new Uint8Array();
-    if (body instanceof Uint8Array) {
-      body = createAsyncIterable([body]);
-    }
+    const body = uServerRes.body ?? createAsyncIterable([]);
     return {
       body: pipe(body, (iterable) => {
         return {


### PR DESCRIPTION
Clients can specify timeouts for calls that propagate to the server. For example, the following RPC will fail with `Code.DeadlineExceeded` if it takes more than 10 seconds:

```ts
client.say({sentence: "Hello"}, { timeoutMs: 10 * 1000 });
```

connect-es servers can limit the timeout value that clients may send. For example, the following setting allows 9 seconds:

```ts
await server.register(fastifyConnectPlugin, { 
  routes, 
  maxTimeoutMs: 9 * 1000,
});
```

This PR adds test coverage to give us confidence that the setting works correctly, and to guard against regressions.