### PR TITLE
Add tests for shutdownSignal

### DIFF
--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -95,9 +95,11 @@ export interface UniversalHandlerOptions {
 
   /**
    * To shut down servers gracefully, this option takes an AbortSignal.
-   * If this signal is aborted, all `deadline` AbortSignals in handler contexts
-   * will be aborted as well. This gives implementations a chance to wrap up
-   * work before the server process is killed.
+   * If this signal is aborted, all signals in handler contexts will be aborted
+   * as well. This gives implementations a chance to wrap up work before the
+   * server process is killed.
+   * Abort this signal with a ConnectError to send a message and code to
+   * clients.
    */
   shutdownSignal?: AbortSignal;
 


### PR DESCRIPTION
Server plugins take a `shutdownSignal` option that can be used to stop long-running RPCs. For example:

```ts
const shutdown = new AbortController();

const router = createConnectRouter({
  shutdownSignal: shutdown.signal,
});

// later:
shutdown.abort(new ConnectError("shutting down", Code.Unavailable));
```

The signal will trigger the `signal` property in `HandlerContext`. For example:

```ts
function say(request: SayRequest, context: HandlerContext) {
  // Raises the ConnectError with Code.Unavailable from above
  // Raising the ConnectError here will send it to clients
  context.signal.throwIfAborted();
}
```

This PR adds test coverage to give us confidence that the setting works correctly, and to guard against regressions.