### PR TITLE
Fix spelling in JSDoc and error messages

### DIFF
--- a/packages/connect-node-test/src/badweather/broken-input.spec.ts
+++ b/packages/connect-node-test/src/badweather/broken-input.spec.ts
@@ -27,7 +27,6 @@ describe("broken input", () => {
   const servers = createTestServers();
   beforeAll(async () => await servers.start());
 
-  // TODO(TCN-785) add @bufbuild/connect-node, cover gRPC and gRPC-web, cover invalid protobuf binary input
   servers.describeServers(
     ["connect-go (h2)", "@bufbuild/connect-node (h2c)"],
     (server, serverName) => {

--- a/packages/connect-node/src/node-error.ts
+++ b/packages/connect-node/src/node-error.ts
@@ -115,7 +115,7 @@ export function getNodeErrorProps(reason: unknown): {
 }
 
 /**
- * Returns a ConnectError for a HTTP/2 error code.
+ * Returns a ConnectError for an HTTP/2 error code.
  */
 export function connectErrorFromH2ResetCode(
   rstCode: number
@@ -129,42 +129,42 @@ export function connectErrorFromH2ResetCode(
     case H2Code.COMPRESSION_ERROR:
     case H2Code.CONNECT_ERROR:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.Internal
       );
     case H2Code.REFUSED_STREAM:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.Unavailable
       );
     case H2Code.CANCEL:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.Canceled
       );
     case H2Code.ENHANCE_YOUR_CALM:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.ResourceExhausted
       );
     case H2Code.INADEQUATE_SECURITY:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.PermissionDenied
       );
     case H2Code.HTTP_1_1_REQUIRED:
       return new ConnectError(
-        `http/2 stream closed with RST code ${
+        `http/2 stream closed with error code ${
           H2Code[rstCode]
         } (0x${rstCode.toString(16)})`,
         Code.PermissionDenied

--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -112,7 +112,7 @@ describe("universal node http client", function () {
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
           expect(ConnectError.from(e).message).toBe(
-            "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+            "[canceled] http/2 stream closed with error code CANCEL (0x8)"
           );
         }
         expect(serverReceivedRequest).toBeTrue();
@@ -178,7 +178,7 @@ describe("universal node http client", function () {
           expect(e).toBeInstanceOf(ConnectError);
           expect(e).toBeInstanceOf(ConnectError);
           expect(ConnectError.from(e).message).toBe(
-            "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+            "[canceled] http/2 stream closed with error code CANCEL (0x8)"
           );
         }
       });
@@ -253,7 +253,7 @@ describe("universal node http client", function () {
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
           expect(ConnectError.from(e).message).toBe(
-            "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+            "[canceled] http/2 stream closed with error code CANCEL (0x8)"
           );
         }
         expect(serverReceivedBytes).toBe(32);
@@ -337,7 +337,7 @@ describe("universal node http client", function () {
           expect(e).toBeInstanceOf(ConnectError);
           expect(e).toBeInstanceOf(ConnectError);
           expect(ConnectError.from(e).message).toBe(
-            "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+            "[canceled] http/2 stream closed with error code CANCEL (0x8)"
           );
         }
         expect(serverSentBytes).toBe(64);

--- a/packages/connect-node/src/node-universal-handler.spec.ts
+++ b/packages/connect-node/src/node-universal-handler.spec.ts
@@ -92,7 +92,7 @@ describe("universalRequestFromNodeRequest()", function () {
       expect(serverRequest?.signal.reason).toBeInstanceOf(ConnectError);
       const ce = ConnectError.from(serverRequest?.signal.reason);
       expect(ce.message).toBe(
-        "[canceled] http/2 stream closed with RST code CANCEL (0x8)"
+        "[canceled] http/2 stream closed with error code CANCEL (0x8)"
       );
     });
     it("should silently end request body stream for CANCEL", async function () {
@@ -112,7 +112,7 @@ describe("universalRequestFromNodeRequest()", function () {
       expect(serverRequest?.signal.reason).toBeInstanceOf(ConnectError);
       const ce = ConnectError.from(serverRequest?.signal.reason);
       expect(ce.message).toBe(
-        "[resource_exhausted] http/2 stream closed with RST code ENHANCE_YOUR_CALM (0xb)"
+        "[resource_exhausted] http/2 stream closed with error code ENHANCE_YOUR_CALM (0xb)"
       );
     });
     it("should silently end request body stream for ENHANCE_YOUR_CALM", async function () {
@@ -132,7 +132,7 @@ describe("universalRequestFromNodeRequest()", function () {
       expect(serverRequest?.signal.reason).toBeInstanceOf(ConnectError);
       const ce = ConnectError.from(serverRequest?.signal.reason);
       expect(ce.message).toBe(
-        "[internal] http/2 stream closed with RST code FRAME_SIZE_ERROR (0x6)"
+        "[internal] http/2 stream closed with error code FRAME_SIZE_ERROR (0x6)"
       );
     });
     it("should silently end request body stream for FRAME_SIZE_ERROR", async function () {

--- a/packages/connect/src/cors.ts
+++ b/packages/connect/src/cors.ts
@@ -76,7 +76,7 @@ export const cors = {
   exposedHeaders: [
     grpcWeb.headerGrpcStatus, // Crucial for gRPC-web
     grpcWeb.headerGrpcMessage, // Crucial for gRPC-web
-    grpcWeb.headerStatusDetailsBin, // Error details in gRCP, gRPC-web
+    grpcWeb.headerStatusDetailsBin, // Error details in gRPC, gRPC-web
     connect.headerUnaryEncoding, // Unused in web browsers, but added for future-proofing
     connect.headerStreamEncoding, // Unused in web browsers, but added for future-proofing
   ] as ReadonlyArray<string>,

--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -82,7 +82,7 @@ export interface ConnectRouterOptions extends Partial<UniversalHandlerOptions> {
 
   /**
    * Enable the gRPC-web protocol and make your API available to all gRPC-web
-   * clients. gRCP-web is commonly used in web browsers, but there are client
+   * clients. gRPC-web is commonly used in web browsers, but there are client
    * implementations for other platforms as well, for example in Dart, Kotlin,
    * and Swift. See https://github.com/grpc/grpc-web
    *


### PR DESCRIPTION
- In a few places, we have "RCP" in JSDoc comments. Fix with "RPC".
- If an HTTP/2 stream is closed with an error code, use wording "error code" instead of "RST code".
- Remove a TODO that has been done