### PR TITLE
Manage HTTP/2 connections and keep them alive with PING frames

### DIFF
--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -17,8 +17,7 @@ import * as http from "http";
 import * as https from "https";
 import * as fs from "fs";
 import * as path from "path";
-import { createRouterTransport, type Transport } from "@bufbuild/connect";
-import { cors } from "@bufbuild/connect";
+import { cors, createRouterTransport, type Transport } from "@bufbuild/connect";
 import {
   compressionGzip,
   connectNodeAdapter,
@@ -28,12 +27,12 @@ import {
 } from "@bufbuild/connect-node";
 import { fastifyConnectPlugin } from "@bufbuild/connect-fastify";
 import { expressConnectMiddleware } from "@bufbuild/connect-express";
-import { fastify } from "fastify";
 import type {
   FastifyBaseLogger,
   FastifyInstance,
   FastifyTypeProviderDefault,
 } from "fastify";
+import { fastify } from "fastify";
 import { importExpress } from "./import-express.js";
 import { testRoutes } from "./test-routes.js";
 
@@ -331,7 +330,6 @@ export function createTestServers() {
   };
 
   const transports = {
-    // TODO add http1.1 transports once implemented
     // gRPC
     "@bufbuild/connect-node (gRPC, binary, http2) against @bufbuild/connect-node (h2)":
       (options?: Record<string, unknown>) =>
@@ -339,6 +337,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             ca: certLocalhost.cert,
           },
@@ -350,6 +349,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
         }),
     "@bufbuild/connect-node (gRPC, JSON, http2) against @bufbuild/connect-node (h2c)":
@@ -358,6 +358,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
         }),
     "@bufbuild/connect-node (gRPC, binary, http2, gzip) against @bufbuild/connect-node (h2c)":
@@ -366,6 +367,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
@@ -375,6 +377,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
           sendCompression: compressionGzip,
         }),
@@ -385,6 +388,7 @@ export function createTestServers() {
         ...options,
         baseUrl: servers["connect-go (h1)"].getUrl(),
         httpVersion: "2",
+        idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
         nodeOptions: {
           rejectUnauthorized: false, // TODO set up cert for go server correctly
         },
@@ -396,6 +400,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -408,6 +413,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -421,6 +427,7 @@ export function createTestServers() {
         ...options,
         baseUrl: servers["connect-go (h1)"].getUrl(),
         httpVersion: "2",
+        idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
         nodeOptions: {
           rejectUnauthorized: false, // TODO set up cert for go server correctly
         },
@@ -433,6 +440,7 @@ export function createTestServers() {
         ...options,
         baseUrl: servers["grpc-go (h2)"].getUrl(),
         httpVersion: "2",
+        idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
         nodeOptions: {
           rejectUnauthorized: false, // TODO set up cert for go server correctly
         },
@@ -549,6 +557,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
@@ -558,6 +567,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
           sendCompression: compressionGzip,
         }),
@@ -588,6 +598,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
@@ -597,6 +608,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -609,6 +621,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
           sendCompression: compressionGzip,
         }),
@@ -618,6 +631,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -740,6 +754,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
           sendCompression: compressionGzip,
         }),
@@ -749,6 +764,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
@@ -778,6 +794,7 @@ export function createTestServers() {
         createGrpcWebTransport({
           ...options,
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           useBinaryFormat: true,
         }),
@@ -787,6 +804,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
         }),
     "@bufbuild/connect-node (gRPC-web, binary, http2) against connect-go (h1)":
@@ -795,6 +813,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -806,6 +825,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -818,6 +838,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["connect-go (h1)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -830,6 +851,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -842,6 +864,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           nodeOptions: {
             rejectUnauthorized: false, // TODO set up cert for go server correctly
           },
@@ -855,6 +878,7 @@ export function createTestServers() {
         ...options,
         baseUrl: servers["connect-go (h1)"].getUrl(),
         httpVersion: "2",
+        idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
         nodeOptions: {
           rejectUnauthorized: false, // TODO set up cert for go server correctly
         },
@@ -963,6 +987,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: true,
           sendCompression: compressionGzip,
         }),
@@ -972,6 +997,7 @@ export function createTestServers() {
           ...options,
           baseUrl: servers["@bufbuild/connect-fastify (h2c)"].getUrl(),
           httpVersion: "2",
+          idleConnectionTimeoutMs: 25, // automatically close connection without streams so the server shuts down quickly after tests
           useBinaryFormat: false,
           sendCompression: compressionGzip,
         }),

--- a/packages/connect-node-test/src/transports.spec.ts
+++ b/packages/connect-node-test/src/transports.spec.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Code, ConnectError } from "@bufbuild/connect";
 import {
   createConnectTransport,
   Http2SessionManager,
 } from "@bufbuild/connect-node";
-import { Code, ConnectError } from "@bufbuild/connect";
 
 describe("createConnectTransport()", function () {
   it("should take just httpVersion and baseUrl", function () {
@@ -86,5 +86,25 @@ describe("using a session manager to open a connection before starting an applic
       }
     }
     // here we would enter the application logic, and start calling RPCs
+  });
+});
+
+describe("using a session manager to explicitly close all connections", function () {
+  it("should work", function () {
+    // create a client, keeping a reference to the session manage
+    const sessionManager = new Http2SessionManager(
+      "https://demo.connect.build"
+    );
+    createConnectTransport({
+      httpVersion: "2",
+      baseUrl: "https://demo.connect.build",
+      sessionManager,
+    });
+    // const client = createPromiseClient(..., transport);
+
+    // make calls with the client
+
+    // close the connection
+    sessionManager.abort();
   });
 });

--- a/packages/connect-node-test/src/transports.spec.ts
+++ b/packages/connect-node-test/src/transports.spec.ts
@@ -1,0 +1,90 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createConnectTransport,
+  Http2SessionManager,
+} from "@bufbuild/connect-node";
+import { Code, ConnectError } from "@bufbuild/connect";
+
+describe("createConnectTransport()", function () {
+  it("should take just httpVersion and baseUrl", function () {
+    const t = createConnectTransport({
+      httpVersion: "2",
+      baseUrl: "https://example.com",
+    });
+    expect(t).toBeDefined();
+  });
+  it("should take session options", function () {
+    const t = createConnectTransport({
+      httpVersion: "2",
+      baseUrl: "https://example.com",
+      pingIntervalMs: 1000 * 30,
+      pingIdleConnection: true,
+      pingTimeoutMs: 1000 * 5,
+      idleConnectionTimeoutMs: 1000 * 60 * 5,
+    });
+    expect(t).toBeDefined();
+  });
+  it("should take node options", function () {
+    const t = createConnectTransport({
+      httpVersion: "2",
+      baseUrl: "https://example.com",
+      nodeOptions: {
+        maxSessionMemory: 1024 * 1024 * 4,
+      },
+    });
+    expect(t).toBeDefined();
+  });
+  it("should take session manager", function () {
+    const sm = new Http2SessionManager(
+      "https://example.com",
+      {
+        pingIntervalMs: 1000 * 10,
+      },
+      {
+        maxSessionMemory: 1024 * 1024 * 4,
+      }
+    );
+    const t = createConnectTransport({
+      httpVersion: "2",
+      baseUrl: "https://example.com",
+      sessionManager: sm,
+    });
+    expect(t).toBeDefined();
+  });
+});
+
+describe("using a session manager to open a connection before starting an application", function () {
+  it("should work", async function () {
+    const sm = new Http2SessionManager("https://demo.connect.build");
+    for (let backoff = 1; ; backoff++) {
+      const state = await sm.connect();
+      if (state == "error") {
+        // For a transient error, we can retry here
+        const reason = sm.error();
+        if (ConnectError.from(reason).code !== Code.Unavailable) {
+          throw sm.error();
+        }
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, backoff * 1000)
+        );
+      } else {
+        // we are connected (either open or idle), break the loop
+        break;
+      }
+    }
+    // here we would enter the application logic, and start calling RPCs
+  });
+});

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -21,103 +21,107 @@ import type {
 import type { Interceptor, Transport } from "@bufbuild/connect";
 import type { Compression } from "@bufbuild/connect/protocol";
 import { createTransport } from "@bufbuild/connect/protocol-connect";
-import { validateNodeTransportOptions } from "./node-transport-options.js";
-import type { NodeHttpClientOptions } from "./node-universal-client.js";
+import {
+  type DeprecatedNodeTransportOptions,
+  type NodeTransportOptions,
+  validateNodeTransportOptions,
+} from "./node-transport-options.js";
 
 /**
  * Options used to configure the Connect transport.
  *
  * See createConnectTransport().
  */
-type ConnectTransportOptions = NodeHttpClientOptions & {
-  /**
-   * Base URI for all HTTP requests.
-   *
-   * Requests will be made to <baseUrl>/<package>.<service>/method
-   *
-   * Example: `baseUrl: "https://example.com/my-api"`
-   *
-   * This will make a `POST /my-api/my_package.MyService/Foo` to
-   * `example.com` via HTTPS.
-   */
-  baseUrl: string;
+type ConnectTransportOptions = NodeTransportOptions &
+  DeprecatedNodeTransportOptions & {
+    /**
+     * Base URI for all HTTP requests.
+     *
+     * Requests will be made to <baseUrl>/<package>.<service>/method
+     *
+     * Example: `baseUrl: "https://example.com/my-api"`
+     *
+     * This will make a `POST /my-api/my_package.MyService/Foo` to
+     * `example.com` via HTTPS.
+     */
+    baseUrl: string;
 
-  /**
-   * By default, connect-node clients use the binary format.
-   */
-  useBinaryFormat?: boolean;
+    /**
+     * By default, connect-node clients use the binary format.
+     */
+    useBinaryFormat?: boolean;
 
-  /**
-   * Interceptors that should be applied to all calls running through
-   * this transport. See the Interceptor type for details.
-   */
-  interceptors?: Interceptor[];
+    /**
+     * Interceptors that should be applied to all calls running through
+     * this transport. See the Interceptor type for details.
+     */
+    interceptors?: Interceptor[];
 
-  /**
-   * Options for the JSON format.
-   */
-  jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+    /**
+     * Options for the JSON format.
+     */
+    jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
 
-  /**
-   * Options for the binary wire format.
-   */
-  binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+    /**
+     * Options for the binary wire format.
+     */
+    binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  /**
-   * Compression algorithms available to a client. Clients ask servers to
-   * compress responses using any of the registered algorithms. The first
-   * registered algorithm is the most preferred.
-   *
-   * It is safe to use this option liberally: servers will ignore any
-   * compression algorithms they don't support. To compress requests, pair this
-   * option with `sendCompression`.
-   *
-   * If this option is not provided, the compression algorithms "gzip" and "br"
-   * (Brotli) are accepted. To opt out of response compression, pass an
-   * empty array.
-   */
-  acceptCompression?: Compression[];
+    /**
+     * Compression algorithms available to a client. Clients ask servers to
+     * compress responses using any of the registered algorithms. The first
+     * registered algorithm is the most preferred.
+     *
+     * It is safe to use this option liberally: servers will ignore any
+     * compression algorithms they don't support. To compress requests, pair this
+     * option with `sendCompression`.
+     *
+     * If this option is not provided, the compression algorithms "gzip" and "br"
+     * (Brotli) are accepted. To opt out of response compression, pass an
+     * empty array.
+     */
+    acceptCompression?: Compression[];
 
-  /**
-   * Configures the client to use the specified algorithm to compress request
-   * messages.
-   *
-   * Because some servers don't support compression, clients default to sending
-   * uncompressed requests.
-   */
-  sendCompression?: Compression;
+    /**
+     * Configures the client to use the specified algorithm to compress request
+     * messages.
+     *
+     * Because some servers don't support compression, clients default to sending
+     * uncompressed requests.
+     */
+    sendCompression?: Compression;
 
-  /**
-   * Sets a minimum size threshold for compression: Messages that are smaller
-   * than the configured minimum are sent uncompressed.
-   *
-   * The default value is 1 kibibyte, because the CPU cost of compressing very
-   * small messages usually isn't worth the small reduction in network I/O.
-   */
-  compressMinBytes?: number;
+    /**
+     * Sets a minimum size threshold for compression: Messages that are smaller
+     * than the configured minimum are sent uncompressed.
+     *
+     * The default value is 1 kibibyte, because the CPU cost of compressing very
+     * small messages usually isn't worth the small reduction in network I/O.
+     */
+    compressMinBytes?: number;
 
-  /**
-   * Limits the performance impact of pathologically large messages sent by the
-   * server. Limits apply to each individual message, not to the stream as a
-   * whole.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  readMaxBytes?: number;
+    /**
+     * Limits the performance impact of pathologically large messages sent by the
+     * server. Limits apply to each individual message, not to the stream as a
+     * whole.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    readMaxBytes?: number;
 
-  /**
-   * Prevents sending messages too large for the server to handle.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  writeMaxBytes?: number;
+    /**
+     * Prevents sending messages too large for the server to handle.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    writeMaxBytes?: number;
 
-  /**
-   * Controls whether or not Connect GET requests should be used when
-   * available, on side-effect free methods. Defaults to false.
-   */
-  useHttpGet?: boolean;
-};
+    /**
+     * Controls whether or not Connect GET requests should be used when
+     * available, on side-effect free methods. Defaults to false.
+     */
+    useHttpGet?: boolean;
+  };
 
 /**
  * Create a Transport for the Connect protocol using the Node.js `http`, `http2`,

--- a/packages/connect-node/src/grpc-transport.ts
+++ b/packages/connect-node/src/grpc-transport.ts
@@ -21,98 +21,102 @@ import type {
   JsonReadOptions,
   JsonWriteOptions,
 } from "@bufbuild/protobuf";
-import { validateNodeTransportOptions } from "./node-transport-options.js";
-import type { NodeHttpClientOptions } from "./node-universal-client.js";
+import {
+  type DeprecatedNodeTransportOptions,
+  type NodeTransportOptions,
+  validateNodeTransportOptions,
+} from "./node-transport-options.js";
 
 /**
  * Options used to configure the gRPC-web transport.
  *
  * See createGrpcTransport().
  */
-type GrpcTransportOptions = NodeHttpClientOptions & {
-  /**
-   * Base URI for all HTTP requests.
-   *
-   * Requests will be made to <baseUrl>/<package>.<service>/method
-   *
-   * Example: `baseUrl: "https://example.com/my-api"`
-   *
-   * This will make a `POST /my-api/my_package.MyService/Foo` to
-   * `example.com` via HTTPS.
-   */
-  baseUrl: string;
+type GrpcTransportOptions = NodeTransportOptions &
+  DeprecatedNodeTransportOptions & {
+    /**
+     * Base URI for all HTTP requests.
+     *
+     * Requests will be made to <baseUrl>/<package>.<service>/method
+     *
+     * Example: `baseUrl: "https://example.com/my-api"`
+     *
+     * This will make a `POST /my-api/my_package.MyService/Foo` to
+     * `example.com` via HTTPS.
+     */
+    baseUrl: string;
 
-  /**
-   * By default, clients use the binary format for gRPC-web, because
-   * not all gRPC-web implementations support JSON.
-   */
-  useBinaryFormat?: boolean;
+    /**
+     * By default, clients use the binary format for gRPC-web, because
+     * not all gRPC-web implementations support JSON.
+     */
+    useBinaryFormat?: boolean;
 
-  /**
-   * Interceptors that should be applied to all calls running through
-   * this transport. See the Interceptor type for details.
-   */
-  interceptors?: Interceptor[];
+    /**
+     * Interceptors that should be applied to all calls running through
+     * this transport. See the Interceptor type for details.
+     */
+    interceptors?: Interceptor[];
 
-  /**
-   * Options for the JSON format.
-   */
-  jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+    /**
+     * Options for the JSON format.
+     */
+    jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
 
-  /**
-   * Options for the binary wire format.
-   */
-  binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+    /**
+     * Options for the binary wire format.
+     */
+    binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  /**
-   * Compression algorithms available to a client. Clients ask servers to
-   * compress responses using any of the registered algorithms. The first
-   * registered algorithm is the most preferred.
-   *
-   * It is safe to use this option liberally: servers will ignore any
-   * compression algorithms they don't support. To compress requests, pair this
-   * option with `sendCompression`.
-   *
-   * If this option is not provided, the compression algorithms "gzip" and "br"
-   * (Brotli) are accepted. To opt out of response compression, pass an
-   * empty array.
-   */
-  acceptCompression?: Compression[];
+    /**
+     * Compression algorithms available to a client. Clients ask servers to
+     * compress responses using any of the registered algorithms. The first
+     * registered algorithm is the most preferred.
+     *
+     * It is safe to use this option liberally: servers will ignore any
+     * compression algorithms they don't support. To compress requests, pair this
+     * option with `sendCompression`.
+     *
+     * If this option is not provided, the compression algorithms "gzip" and "br"
+     * (Brotli) are accepted. To opt out of response compression, pass an
+     * empty array.
+     */
+    acceptCompression?: Compression[];
 
-  /**
-   * Configures the client to use the specified algorithm to compress request
-   * messages.
-   *
-   * Because some servers don't support compression, clients default to sending
-   * uncompressed requests.
-   */
-  sendCompression?: Compression;
+    /**
+     * Configures the client to use the specified algorithm to compress request
+     * messages.
+     *
+     * Because some servers don't support compression, clients default to sending
+     * uncompressed requests.
+     */
+    sendCompression?: Compression;
 
-  /**
-   * Sets a minimum size threshold for compression: Messages that are smaller
-   * than the configured minimum are sent uncompressed.
-   *
-   * The default value is 1 kibibyte, because the CPU cost of compressing very
-   * small messages usually isn't worth the small reduction in network I/O.
-   */
-  compressMinBytes?: number;
+    /**
+     * Sets a minimum size threshold for compression: Messages that are smaller
+     * than the configured minimum are sent uncompressed.
+     *
+     * The default value is 1 kibibyte, because the CPU cost of compressing very
+     * small messages usually isn't worth the small reduction in network I/O.
+     */
+    compressMinBytes?: number;
 
-  /**
-   * Limits the performance impact of pathologically large messages sent by the
-   * server. Limits apply to each individual message, not to the stream as a
-   * whole.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  readMaxBytes?: number;
+    /**
+     * Limits the performance impact of pathologically large messages sent by the
+     * server. Limits apply to each individual message, not to the stream as a
+     * whole.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    readMaxBytes?: number;
 
-  /**
-   * Prevents sending messages too large for the server to handle.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  writeMaxBytes?: number;
-};
+    /**
+     * Prevents sending messages too large for the server to handle.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    writeMaxBytes?: number;
+  };
 
 /**
  * Create a Transport for the gRPC protocol using the Node.js `http`, `http2`,

--- a/packages/connect-node/src/grpc-web-transport.ts
+++ b/packages/connect-node/src/grpc-web-transport.ts
@@ -21,98 +21,102 @@ import type {
   JsonReadOptions,
   JsonWriteOptions,
 } from "@bufbuild/protobuf";
-import { validateNodeTransportOptions } from "./node-transport-options.js";
-import type { NodeHttpClientOptions } from "./node-universal-client.js";
+import {
+  type DeprecatedNodeTransportOptions,
+  type NodeTransportOptions,
+  validateNodeTransportOptions,
+} from "./node-transport-options.js";
 
 /**
  * Options used to configure the gRPC-web transport.
  *
  * See createGrpcWebTransport().
  */
-type GrpcWebTransportOptions = NodeHttpClientOptions & {
-  /**
-   * Base URI for all HTTP requests.
-   *
-   * Requests will be made to <baseUrl>/<package>.<service>/method
-   *
-   * Example: `baseUrl: "https://example.com/my-api"`
-   *
-   * This will make a `POST /my-api/my_package.MyService/Foo` to
-   * `example.com` via HTTPS.
-   */
-  baseUrl: string;
+type GrpcWebTransportOptions = NodeTransportOptions &
+  DeprecatedNodeTransportOptions & {
+    /**
+     * Base URI for all HTTP requests.
+     *
+     * Requests will be made to <baseUrl>/<package>.<service>/method
+     *
+     * Example: `baseUrl: "https://example.com/my-api"`
+     *
+     * This will make a `POST /my-api/my_package.MyService/Foo` to
+     * `example.com` via HTTPS.
+     */
+    baseUrl: string;
 
-  /**
-   * By default, clients use the binary format for gRPC-web, because
-   * not all gRPC-web implementations support JSON.
-   */
-  useBinaryFormat?: boolean;
+    /**
+     * By default, clients use the binary format for gRPC-web, because
+     * not all gRPC-web implementations support JSON.
+     */
+    useBinaryFormat?: boolean;
 
-  /**
-   * Interceptors that should be applied to all calls running through
-   * this transport. See the Interceptor type for details.
-   */
-  interceptors?: Interceptor[];
+    /**
+     * Interceptors that should be applied to all calls running through
+     * this transport. See the Interceptor type for details.
+     */
+    interceptors?: Interceptor[];
 
-  /**
-   * Options for the JSON format.
-   */
-  jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
+    /**
+     * Options for the JSON format.
+     */
+    jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
 
-  /**
-   * Options for the binary wire format.
-   */
-  binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
+    /**
+     * Options for the binary wire format.
+     */
+    binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
-  /**
-   * Compression algorithms available to a client. Clients ask servers to
-   * compress responses using any of the registered algorithms. The first
-   * registered algorithm is the most preferred.
-   *
-   * It is safe to use this option liberally: servers will ignore any
-   * compression algorithms they don't support. To compress requests, pair this
-   * option with `sendCompression`.
-   *
-   * If this option is not provided, the compression algorithms "gzip" and "br"
-   * (Brotli) are accepted. To opt out of response compression, pass an
-   * empty array.
-   */
-  acceptCompression?: Compression[];
+    /**
+     * Compression algorithms available to a client. Clients ask servers to
+     * compress responses using any of the registered algorithms. The first
+     * registered algorithm is the most preferred.
+     *
+     * It is safe to use this option liberally: servers will ignore any
+     * compression algorithms they don't support. To compress requests, pair this
+     * option with `sendCompression`.
+     *
+     * If this option is not provided, the compression algorithms "gzip" and "br"
+     * (Brotli) are accepted. To opt out of response compression, pass an
+     * empty array.
+     */
+    acceptCompression?: Compression[];
 
-  /**
-   * Configures the client to use the specified algorithm to compress request
-   * messages.
-   *
-   * Because some servers don't support compression, clients default to sending
-   * uncompressed requests.
-   */
-  sendCompression?: Compression;
+    /**
+     * Configures the client to use the specified algorithm to compress request
+     * messages.
+     *
+     * Because some servers don't support compression, clients default to sending
+     * uncompressed requests.
+     */
+    sendCompression?: Compression;
 
-  /**
-   * Sets a minimum size threshold for compression: Messages that are smaller
-   * than the configured minimum are sent uncompressed.
-   *
-   * The default value is 1 kibibyte, because the CPU cost of compressing very
-   * small messages usually isn't worth the small reduction in network I/O.
-   */
-  compressMinBytes?: number;
+    /**
+     * Sets a minimum size threshold for compression: Messages that are smaller
+     * than the configured minimum are sent uncompressed.
+     *
+     * The default value is 1 kibibyte, because the CPU cost of compressing very
+     * small messages usually isn't worth the small reduction in network I/O.
+     */
+    compressMinBytes?: number;
 
-  /**
-   * Limits the performance impact of pathologically large messages sent by the
-   * server. Limits apply to each individual message, not to the stream as a
-   * whole.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  readMaxBytes?: number;
+    /**
+     * Limits the performance impact of pathologically large messages sent by the
+     * server. Limits apply to each individual message, not to the stream as a
+     * whole.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    readMaxBytes?: number;
 
-  /**
-   * Prevents sending messages too large for the server to handle.
-   *
-   * The default limit is the maximum supported value of ~4GiB.
-   */
-  writeMaxBytes?: number;
-};
+    /**
+     * Prevents sending messages too large for the server to handle.
+     *
+     * The default limit is the maximum supported value of ~4GiB.
+     */
+    writeMaxBytes?: number;
+  };
 
 /**
  * Create a Transport for the gRPC-web protocol using the Node.js `http`,

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -1,0 +1,493 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useNodeServer } from "./use-node-server-helper.spec.js";
+import * as http2 from "http2";
+import { Http2SessionManager } from "./http2-session-manager.js";
+import { ConnectError } from "@bufbuild/connect";
+
+describe("Http2SessionManager", function () {
+  const serverSessions: http2.ServerHttp2Session[] = [];
+  const serverReceivedPings: Buffer[] = [];
+  const server = useNodeServer(() => {
+    serverSessions.splice(0);
+    serverReceivedPings.splice(0);
+    return http2
+      .createServer()
+      .on("session", (s) => serverSessions.push(s))
+      .on("session", (s) =>
+        s.on("ping", (payload: Buffer) => serverReceivedPings.push(payload))
+      )
+      .on("request", () => {
+        // without the listener, node cancels streams
+      });
+  });
+
+  it("should initially be closed", function () {
+    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    expect(sm.state()).toBe("closed");
+  });
+
+  it("should be closed after calling abort()", function () {
+    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    sm.abort();
+    expect(sm.state()).toBe("closed");
+  });
+
+  it("should be error after calling abort() with an error", function () {
+    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    sm.abort(new ConnectError("foo"));
+    expect(sm.state()).toBe("error");
+    expect(String(sm.error())).toBe("ConnectError: [unknown] foo");
+  });
+
+  describe("first request", function () {
+    it("should update state to 'connecting', 'open', and close cleanly after closing the stream", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const reqPromise = sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("connecting");
+      const req = await reqPromise;
+      expect(sm.state()).toBe("open");
+      await new Promise<void>((resolve) =>
+        req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+      expect(sm.state()).toBe("closed");
+    });
+    it("should update state to 'idle', when closing the stream", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const req = await sm.request("POST", "/", {}, {});
+      await new Promise<void>((resolve) =>
+        req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      expect(sm.state()).toBe("idle");
+      sm.abort();
+      expect(sm.state()).toBe("closed");
+    });
+    it("should reject if manager is aborted while connecting", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const reqPromise = sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("connecting");
+      sm.abort();
+      await expectAsync(reqPromise).toBeRejectedWithError(
+        /\[canceled] connection aborted/
+      );
+      expect(sm.state()).toBe("closed");
+    });
+    it("should error if manager aborts", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const req = await sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("open");
+      let reqError: unknown;
+      req.on("error", (err: unknown) => {
+        reqError = err;
+      });
+      expect(req.destroyed).toBeFalse();
+      sm.abort();
+      // wait for next tick
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(req.destroyed).toBeTrue();
+      expect(String(reqError)).toBe(
+        "ConnectError: [canceled] connection aborted"
+      );
+      expect(sm.state()).toBe("closed");
+    });
+  });
+
+  describe("second request", function () {
+    it("should re-use the existing connection", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const req1 = await sm.request("POST", "/", {}, {});
+      const req2 = await sm.request("POST", "/", {}, {});
+      expect(req1.session === req2.session)
+        .withContext(
+          "session for second request is re-using connection from first request"
+        )
+        .toBeTrue();
+
+      // clean up
+      await new Promise<void>((resolve) =>
+        req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      await new Promise<void>((resolve) =>
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+    });
+    it("should verify idle connection", async function () {
+      const sm = new Http2SessionManager(
+        server.getUrl(),
+        {
+          pingIntervalMs: 10, // intentionally short to trigger verification in tests
+        },
+        {}
+      );
+
+      // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
+      const req1 = await sm.request("POST", "/", {}, {});
+      const req1Session = req1.session;
+      await new Promise<void>((resolve) =>
+        req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      expect(sm.state())
+        .withContext("connection state after issuing a request and closing it")
+        .toBe("idle");
+      await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+      // issue another request, which should verify the connection first with successful PING within timeout
+      serverReceivedPings.splice(0);
+      const req2Promise = sm.request("POST", "/", {}, {});
+      expect(sm.state())
+        .withContext("connection unused for more than verifyAgeMs")
+        .toBe("verifying");
+      const req2 = await req2Promise;
+      expect(serverReceivedPings.length)
+        .withContext("server received ping for verification")
+        .toBeGreaterThan(0);
+      expect(sm.state())
+        .withContext("connection after verification")
+        .toBe("open");
+      expect(req1Session === req2.session)
+        .withContext(
+          "connection for second request is re-using connection from first request"
+        )
+        .toBeTrue();
+
+      // clean up
+      await new Promise<void>((resolve) =>
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+      expect(sm.state()).toBe("closed");
+    });
+    it("should open a new connection if verification for the old one fails", async function () {
+      const sm = new Http2SessionManager(
+        server.getUrl(),
+        {
+          pingTimeoutMs: 0, // intentionally unsatisfiable
+          pingIntervalMs: 10, // intentionally short to trigger verification in tests
+        },
+        {}
+      );
+
+      // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
+      const req1 = await sm.request("POST", "/", {}, {});
+      const req1Session = req1.session;
+      await new Promise<void>((resolve) =>
+        req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      expect(sm.state())
+        .withContext("connection state after issuing a request and closing it")
+        .toBe("idle");
+      await new Promise<void>((resolve) => setTimeout(resolve, 30)); // intentionally longer than pingIntervalMs
+
+      // issue another request, which should verify the connection first
+      const req2Promise = sm.request("POST", "/", {}, {});
+      expect(sm.state())
+        .withContext("connection unused for more than verifyAgeMs")
+        .toBe("verifying");
+      const req2 = await req2Promise;
+      expect(sm.state())
+        .withContext("connection after verification")
+        .toBe("open");
+      expect(req1Session !== req2.session)
+        .withContext(
+          "connection for second request is using a new connection instead of the one from the first request"
+        )
+        .toBeTrue();
+
+      // clean up
+      await new Promise<void>((resolve) =>
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+      expect(sm.state()).toBe("closed");
+    });
+  });
+
+  describe("receiving a GOAWAY frame with error ENHANCE_YOUR_CALM and debug data too_many_pings", function () {
+    it("should use double the original pingIntervalMs for a second connection", async function () {
+      const sm = new Http2SessionManager(
+        server.getUrl(),
+        {
+          pingIntervalMs: 20, // intentionally small for faster tests
+        },
+        {}
+      );
+
+      // issue a request to open a connection
+      let req1Error: unknown;
+      const req1 = await sm.request("POST", "/", {}, {});
+      req1.on("error", (err) => (req1Error = err as unknown));
+      expect(sm.state())
+        .withContext("connection state after issuing a request and closing it")
+        .toBe("open");
+      await new Promise<void>((resolve) => setTimeout(resolve, 10)); // wait for server to receive request
+
+      // on the server, send a GOAWAY frame with code ENHANCE_YOUR_CALM and ASCII debug data "too_many_pings"
+      expect(serverSessions.length).toBe(1);
+      const tooManyPingsAscii = Buffer.from("too_many_pings", "ascii");
+      serverSessions[0].goaway(
+        http2.constants.NGHTTP2_ENHANCE_YOUR_CALM,
+        undefined,
+        tooManyPingsAscii
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+      // expect client session and stream to close
+      expect(String(req1Error))
+        .withContext("node automatically destroys streams on GOAWAY")
+        .toBe(
+          "Error [ERR_HTTP2_SESSION_ERROR]: Session closed with error code 11"
+        );
+      expect(sm.state())
+        .withContext("connection state after receiving GOAWAY")
+        .toBe("error");
+      expect(String(sm.error()))
+        .withContext("connect error wrapped by us with additional information")
+        .toBe(
+          "ConnectError: [resource_exhausted] http/2 connection closed with error code ENHANCE_YOUR_CALM (0xb), too_many_pings, doubled the interval"
+        );
+
+      // second connection should use double pingIntervalMs
+      const req2 = await sm.request("POST", "/", {}, {});
+      serverReceivedPings.splice(0);
+      await new Promise<void>((resolve) => setTimeout(resolve, 20 + 10)); // original pingIntervalMs + leeway
+      expect(serverReceivedPings.length)
+        .withContext("pings sent within original pingIntervalMs + leeway")
+        .toBe(0);
+
+      // ideally, we should assert that a ping is sent within double pingIntervalMs,
+      // but it makes the test very flaky
+
+      // clean up
+      await new Promise<void>((resolve) =>
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+    });
+  });
+
+  describe("ping frames", function () {
+    describe("for open streams", function () {
+      it("should be sent", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 5, // intentionally short for faster tests
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        expect(serverReceivedPings.length).toBeGreaterThanOrEqual(2);
+        await new Promise<void>((resolve) =>
+          req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+        );
+        sm.abort();
+        expect(sm.state()).toBe("closed");
+      });
+      it("should not be sent while client is receiving data", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 10, // intentionally short for faster tests
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        for (let i = 0; i < 30; i++) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 1));
+          sm.notifyResponseByteRead(req);
+        }
+        expect(serverReceivedPings.length).toBe(0);
+
+        // clean up
+        await new Promise<void>((resolve) =>
+          req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+        );
+        sm.abort();
+        expect(sm.state()).toBe("closed");
+      });
+      it("should destroy the connection if not answered in time", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 5, // intentionally short for faster tests
+            pingTimeoutMs: 0, // intentionally unsatisfiable
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        const reqErrors: unknown[] = [];
+        req.on("error", (err) => reqErrors.push(err));
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        expect(reqErrors.length).toBe(1);
+        expect(String(reqErrors[0])).toBe(
+          "ConnectError: [unavailable] PING timed out"
+        );
+        expect(sm.state()).toBe("error");
+        expect(String(sm.error())).toBe(
+          "ConnectError: [unavailable] PING timed out"
+        );
+      });
+    });
+
+    describe("for connections without open streams", function () {
+      it("should not be sent by default", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 5, // intentionally short for faster tests
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        await new Promise<void>((resolve) =>
+          req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+        );
+        expect(sm.state()).toBe("idle");
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        expect(serverReceivedPings.length).toBe(0);
+        sm.abort();
+      });
+      it("should be sent if pingIdleConnection is enabled", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 1, // intentionally short for faster tests
+            pingIdleConnection: true,
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        await new Promise<void>((resolve) =>
+          req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+        );
+        expect(sm.state()).toBe("idle");
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        expect(serverReceivedPings.length).toBeGreaterThan(0);
+
+        // cleanup
+        sm.abort();
+        expect(sm.state()).toBe("closed");
+      });
+      it("should destroy the connection if not answered in time", async function () {
+        const sm = new Http2SessionManager(
+          server.getUrl(),
+          {
+            pingIntervalMs: 5, // intentionally short for faster tests
+            pingTimeoutMs: 0, // intentionally unsatisfiable
+            pingIdleConnection: true,
+          },
+          {}
+        );
+        const req = await sm.request("POST", "/", {}, {});
+        await new Promise<void>((resolve) =>
+          req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        expect(sm.state()).toBe("error");
+        expect(String(sm.error())).toBe(
+          "ConnectError: [unavailable] PING timed out"
+        );
+      });
+    });
+  });
+
+  describe("idle timeout", function () {
+    it("should close the connection", async function () {
+      const sm = new Http2SessionManager(
+        server.getUrl(),
+        {
+          idleConnectionTimeoutMs: 1, // intentionally small for faster tests
+        },
+        {}
+      );
+
+      const req = await sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("open");
+      await new Promise<void>((resolve) =>
+        req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      expect(sm.state()).toBe("idle");
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      expect(sm.state()).toBe("closed");
+    });
+  });
+
+  describe("request against unresolvable host", function () {
+    it("should reject", async function () {
+      const sm = new Http2SessionManager(
+        "https://unresolvable-host.some.domain",
+        {},
+        {}
+      );
+      const reqPromise = sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("connecting");
+      await expectAsync(reqPromise).toBeRejectedWithError(
+        /getaddrinfo ENOTFOUND unresolvable-host.some.domain/
+      );
+      expect(sm.state()).toBe("error");
+    });
+    it("should reject if manager is aborted while connecting", async function () {
+      const sm = new Http2SessionManager(
+        "https://unresolvable-host.some.domain",
+        {},
+        {}
+      );
+      const reqPromise = sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("connecting");
+      sm.abort();
+      await expectAsync(reqPromise).toBeRejectedWithError(
+        /\[canceled] connection aborted/
+      );
+      expect(sm.state()).toBe("closed");
+    });
+  });
+
+  describe("connect", function () {
+    it("should go from closed to idle", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      expect(sm.state()).toBe("closed");
+      await expectAsync(sm.connect()).toBeResolvedTo("idle");
+      sm.abort();
+    });
+    it("should go from error to idle", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      sm.abort(new ConnectError("foo"));
+      expect(sm.state()).toBe("error");
+      await expectAsync(sm.connect()).toBeResolvedTo("idle");
+      sm.abort();
+    });
+    it("should go from idle to idle", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      await expectAsync(sm.connect()).toBeResolvedTo("idle");
+      await expectAsync(sm.connect()).toBeResolvedTo("idle");
+      sm.abort();
+    });
+    it("should go from open to open", async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const req = await sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("open");
+      await expectAsync(sm.connect()).toBeResolvedTo("open");
+
+      // cleanup
+      await new Promise<void>((resolve) =>
+        req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
+      );
+      sm.abort();
+    });
+  });
+});

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -126,12 +126,9 @@ describe("Http2SessionManager", function () {
       sm.abort();
     });
     it("should verify idle connection", async function () {
-      const sm = new Http2SessionManager(
-        server.getUrl(),
-        {
-          pingIntervalMs: 10, // intentionally short to trigger verification in tests
-        }
-      );
+      const sm = new Http2SessionManager(server.getUrl(), {
+        pingIntervalMs: 10, // intentionally short to trigger verification in tests
+      });
 
       // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
       const req1 = await sm.request("POST", "/", {}, {});
@@ -171,13 +168,10 @@ describe("Http2SessionManager", function () {
       expect(sm.state()).toBe("closed");
     });
     it("should open a new connection if verification for the old one fails", async function () {
-      const sm = new Http2SessionManager(
-        server.getUrl(),
-        {
-          pingTimeoutMs: 0, // intentionally unsatisfiable
-          pingIntervalMs: 10, // intentionally short to trigger verification in tests
-        },
-      );
+      const sm = new Http2SessionManager(server.getUrl(), {
+        pingTimeoutMs: 0, // intentionally unsatisfiable
+        pingIntervalMs: 10, // intentionally short to trigger verification in tests
+      });
 
       // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
       const req1 = await sm.request("POST", "/", {}, {});
@@ -216,12 +210,9 @@ describe("Http2SessionManager", function () {
 
   describe("receiving a GOAWAY frame with error ENHANCE_YOUR_CALM and debug data too_many_pings", function () {
     it("should use double the original pingIntervalMs for a second connection", async function () {
-      const sm = new Http2SessionManager(
-        server.getUrl(),
-        {
-          pingIntervalMs: 20, // intentionally small for faster tests
-        },
-      );
+      const sm = new Http2SessionManager(server.getUrl(), {
+        pingIntervalMs: 20, // intentionally small for faster tests
+      });
 
       // issue a request to open a connection
       let req1Error: unknown;
@@ -279,12 +270,9 @@ describe("Http2SessionManager", function () {
   describe("ping frames", function () {
     describe("for open streams", function () {
       it("should be sent", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 5, // intentionally short for faster tests
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 5, // intentionally short for faster tests
+        });
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) => setTimeout(resolve, 50));
         expect(serverReceivedPings.length).toBeGreaterThanOrEqual(2);
@@ -295,12 +283,9 @@ describe("Http2SessionManager", function () {
         expect(sm.state()).toBe("closed");
       });
       it("should not be sent while client is receiving data", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 10, // intentionally short for faster tests
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 10, // intentionally short for faster tests
+        });
         const req = await sm.request("POST", "/", {}, {});
         for (let i = 0; i < 30; i++) {
           await new Promise<void>((resolve) => setTimeout(resolve, 1));
@@ -316,13 +301,10 @@ describe("Http2SessionManager", function () {
         expect(sm.state()).toBe("closed");
       });
       it("should destroy the connection if not answered in time", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 5, // intentionally short for faster tests
-            pingTimeoutMs: 0, // intentionally unsatisfiable
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 5, // intentionally short for faster tests
+          pingTimeoutMs: 0, // intentionally unsatisfiable
+        });
         const req = await sm.request("POST", "/", {}, {});
         const reqErrors: unknown[] = [];
         req.on("error", (err) => reqErrors.push(err));
@@ -340,12 +322,9 @@ describe("Http2SessionManager", function () {
 
     describe("for connections without open streams", function () {
       it("should not be sent by default", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 5, // intentionally short for faster tests
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 5, // intentionally short for faster tests
+        });
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
           req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
@@ -356,13 +335,10 @@ describe("Http2SessionManager", function () {
         sm.abort();
       });
       it("should be sent if pingIdleConnection is enabled", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 1, // intentionally short for faster tests
-            pingIdleConnection: true,
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 1, // intentionally short for faster tests
+          pingIdleConnection: true,
+        });
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
           req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
@@ -376,14 +352,11 @@ describe("Http2SessionManager", function () {
         expect(sm.state()).toBe("closed");
       });
       it("should destroy the connection if not answered in time", async function () {
-        const sm = new Http2SessionManager(
-          server.getUrl(),
-          {
-            pingIntervalMs: 5, // intentionally short for faster tests
-            pingTimeoutMs: 0, // intentionally unsatisfiable
-            pingIdleConnection: true,
-          },
-        );
+        const sm = new Http2SessionManager(server.getUrl(), {
+          pingIntervalMs: 5, // intentionally short for faster tests
+          pingTimeoutMs: 0, // intentionally unsatisfiable
+          pingIdleConnection: true,
+        });
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
           req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
@@ -421,7 +394,7 @@ describe("Http2SessionManager", function () {
   describe("request against unresolvable host", function () {
     it("should reject", async function () {
       const sm = new Http2SessionManager(
-        "https://unresolvable-host.some.domain",
+        "https://unresolvable-host.some.domain"
       );
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");
@@ -432,7 +405,7 @@ describe("Http2SessionManager", function () {
     });
     it("should reject if manager is aborted while connecting", async function () {
       const sm = new Http2SessionManager(
-        "https://unresolvable-host.some.domain",
+        "https://unresolvable-host.some.domain"
       );
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -35,18 +35,18 @@ describe("Http2SessionManager", function () {
   });
 
   it("should initially be closed", function () {
-    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    const sm = new Http2SessionManager(server.getUrl());
     expect(sm.state()).toBe("closed");
   });
 
   it("should be closed after calling abort()", function () {
-    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    const sm = new Http2SessionManager(server.getUrl());
     sm.abort();
     expect(sm.state()).toBe("closed");
   });
 
   it("should be error after calling abort() with an error", function () {
-    const sm = new Http2SessionManager(server.getUrl(), {}, {});
+    const sm = new Http2SessionManager(server.getUrl());
     sm.abort(new ConnectError("foo"));
     expect(sm.state()).toBe("error");
     expect(String(sm.error())).toBe("ConnectError: [unknown] foo");
@@ -54,7 +54,7 @@ describe("Http2SessionManager", function () {
 
   describe("first request", function () {
     it("should update state to 'connecting', 'open', and close cleanly after closing the stream", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");
       const req = await reqPromise;
@@ -66,7 +66,7 @@ describe("Http2SessionManager", function () {
       expect(sm.state()).toBe("closed");
     });
     it("should update state to 'idle', when closing the stream", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const req = await sm.request("POST", "/", {}, {});
       await new Promise<void>((resolve) =>
         req.close(http2.constants.NGHTTP2_NO_ERROR, resolve)
@@ -76,7 +76,7 @@ describe("Http2SessionManager", function () {
       expect(sm.state()).toBe("closed");
     });
     it("should reject if manager is aborted while connecting", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");
       sm.abort();
@@ -86,7 +86,7 @@ describe("Http2SessionManager", function () {
       expect(sm.state()).toBe("closed");
     });
     it("should error if manager aborts", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const req = await sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("open");
       let reqError: unknown;
@@ -107,7 +107,7 @@ describe("Http2SessionManager", function () {
 
   describe("second request", function () {
     it("should re-use the existing connection", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const req1 = await sm.request("POST", "/", {}, {});
       const req2 = await sm.request("POST", "/", {}, {});
       expect(req1.session === req2.session)
@@ -130,8 +130,7 @@ describe("Http2SessionManager", function () {
         server.getUrl(),
         {
           pingIntervalMs: 10, // intentionally short to trigger verification in tests
-        },
-        {}
+        }
       );
 
       // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
@@ -178,7 +177,6 @@ describe("Http2SessionManager", function () {
           pingTimeoutMs: 0, // intentionally unsatisfiable
           pingIntervalMs: 10, // intentionally short to trigger verification in tests
         },
-        {}
       );
 
       // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
@@ -223,7 +221,6 @@ describe("Http2SessionManager", function () {
         {
           pingIntervalMs: 20, // intentionally small for faster tests
         },
-        {}
       );
 
       // issue a request to open a connection
@@ -287,7 +284,6 @@ describe("Http2SessionManager", function () {
           {
             pingIntervalMs: 5, // intentionally short for faster tests
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -304,7 +300,6 @@ describe("Http2SessionManager", function () {
           {
             pingIntervalMs: 10, // intentionally short for faster tests
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         for (let i = 0; i < 30; i++) {
@@ -327,7 +322,6 @@ describe("Http2SessionManager", function () {
             pingIntervalMs: 5, // intentionally short for faster tests
             pingTimeoutMs: 0, // intentionally unsatisfiable
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         const reqErrors: unknown[] = [];
@@ -351,7 +345,6 @@ describe("Http2SessionManager", function () {
           {
             pingIntervalMs: 5, // intentionally short for faster tests
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
@@ -369,7 +362,6 @@ describe("Http2SessionManager", function () {
             pingIntervalMs: 1, // intentionally short for faster tests
             pingIdleConnection: true,
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
@@ -391,7 +383,6 @@ describe("Http2SessionManager", function () {
             pingTimeoutMs: 0, // intentionally unsatisfiable
             pingIdleConnection: true,
           },
-          {}
         );
         const req = await sm.request("POST", "/", {}, {});
         await new Promise<void>((resolve) =>
@@ -431,8 +422,6 @@ describe("Http2SessionManager", function () {
     it("should reject", async function () {
       const sm = new Http2SessionManager(
         "https://unresolvable-host.some.domain",
-        {},
-        {}
       );
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");
@@ -444,8 +433,6 @@ describe("Http2SessionManager", function () {
     it("should reject if manager is aborted while connecting", async function () {
       const sm = new Http2SessionManager(
         "https://unresolvable-host.some.domain",
-        {},
-        {}
       );
       const reqPromise = sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("connecting");
@@ -459,26 +446,26 @@ describe("Http2SessionManager", function () {
 
   describe("connect", function () {
     it("should go from closed to idle", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       expect(sm.state()).toBe("closed");
       await expectAsync(sm.connect()).toBeResolvedTo("idle");
       sm.abort();
     });
     it("should go from error to idle", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       sm.abort(new ConnectError("foo"));
       expect(sm.state()).toBe("error");
       await expectAsync(sm.connect()).toBeResolvedTo("idle");
       sm.abort();
     });
     it("should go from idle to idle", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       await expectAsync(sm.connect()).toBeResolvedTo("idle");
       await expectAsync(sm.connect()).toBeResolvedTo("idle");
       sm.abort();
     });
     it("should go from open to open", async function () {
-      const sm = new Http2SessionManager(server.getUrl(), {}, {});
+      const sm = new Http2SessionManager(server.getUrl());
       const req = await sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("open");
       await expectAsync(sm.connect()).toBeResolvedTo("open");

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -63,7 +63,7 @@ export interface Http2SessionOptions {
    * Automatically close a connection if the time since the last request stream
    * exceeds this value.
    *
-   * Defaults to 5 minutes.
+   * Defaults to 15 minutes.
    *
    * This option is equivalent to GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS of gRPC core.
    */
@@ -159,12 +159,12 @@ export class Http2SessionManager {
       pingTimeoutMs: pingOptions?.pingTimeoutMs ?? 1000 * 15,
       pingIdleConnection: pingOptions?.pingIdleConnection ?? false,
       idleConnectionTimeoutMs:
-        pingOptions?.idleConnectionTimeoutMs ?? 1000 * 60 * 5,
+        pingOptions?.idleConnectionTimeoutMs ?? 1000 * 60 * 15,
     };
   }
 
   /**
-   * Open a connection if none exists, and verify and existing connection if
+   * Open a connection if none exists, verify an existing connection if
    * necessary.
    */
   async connect(): Promise<"open" | "idle" | "error"> {

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -164,6 +164,10 @@ export class Http2SessionManager {
     };
   }
 
+  /**
+   * Open a connection if none exists, and verify and existing connection if
+   * necessary.
+   */
   async connect(): Promise<"open" | "idle" | "error"> {
     try {
       const ready = await this.gotoReady();

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -1,0 +1,717 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as http2 from "http2";
+import { Code, ConnectError } from "@bufbuild/connect";
+
+export interface Http2SessionOptions {
+  /**
+   * The interval to send PING frames to keep a connection alive. The interval
+   * is reset whenever a stream receives data. If a PING frame is not responded
+   * to within pingTimeoutMs, the connection and all open streams close.
+   *
+   * By default, no PING frames are sent. If a value is provided, PING frames
+   * are sent only for connections that have open streams, unless
+   * pingIdleConnections is enabled.
+   *
+   * Sensible values can be between 10 seconds and 2 hours, depending on your
+   * infrastructure.
+   *
+   * This option is equivalent to GRPC_ARG_KEEPALIVE_TIME_MS in gRPC Core.
+   */
+  pingIntervalMs?: number;
+
+  /**
+   * Enable PING frames for connections that are have no open streams.
+   * This option is only effective if a value for pingIntervalMs is provided.
+   *
+   * Note that it may not be necessary to enable this option. If a request is
+   * made on a connection that has not been used for longer than pingIntervalMs,
+   * a PING frame is sent to verify that the connection is still alive, and a
+   * new connection is opened transparently if necessary.
+   *
+   * Defaults to false.
+   *
+   * This option is equivalent to GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS in
+   * gRPC Core.
+   */
+  pingIdleConnection?: boolean;
+
+  /**
+   * Timeout for PING frames. If a PING is not answered within this time, the
+   * connection is considered dead.
+   *
+   * Defaults to 15 seconds. This option is only used if a value for
+   * pingIntervalMs is provided.
+   *
+   * This option is equivalent to GRPC_ARG_KEEPALIVE_TIME_MS in gRPC Core.
+   */
+  pingTimeoutMs?: number;
+
+  /**
+   * Automatically close a connection if the time since the last request stream
+   * exceeds this value.
+   *
+   * Defaults to 5 minutes.
+   *
+   * This option is equivalent to GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS of gRPC core.
+   */
+  idleConnectionTimeoutMs?: number;
+}
+
+// TODO document
+/**
+ * Manages a HTTP/2 connection with Basic Keepalive as described in
+ * https://github.com/grpc/proposal/blob/0ba0c1905050525f9b0aee46f3f23c8e1e515489/A8-client-side-keepalive.md#basic-keepalive
+ */
+export class Http2SessionManager {
+  /**
+   * The host this session manager connect to.
+   */
+  authority: string;
+
+  /**
+   * The current state of the connection:
+   *
+   * - "closed"
+   *   The connection is closed, or no connection has been opened yet.
+   * - connecting
+   *   Currently establishing a connection.
+   *
+   * - "open"
+   *   A connection is open and has open streams. PING frames are sent every
+   *   pingIntervalMs, unless a stream received data.
+   *   If a PING frame is not responded to within pingTimeoutMs, the connection
+   *   and all open streams close.
+   *
+   * - "idle"
+   *   A connection is open, but it does not have any open streams.
+   *   If pingIdleConnection is enabled, PING frames are used to keep the
+   *   connection alive, similar to an "open" connection.
+   *   If a connection is idle for longer than idleConnectionTimeoutMs, it closes.
+   *   If a request is made on an idle connection that has not been used for
+   *   longer than pingIntervalMs, the connection is verified.
+   *
+   * - "verifying"
+   *   Verifying a connection after a long period of inactivity before issuing a
+   *   request. A PING frame is sent, and if it times out within pingTimeoutMs, a
+   *   new connection is opened.
+   *
+   * - "error"
+   *   The connection is closed because of a transient error. A connection
+   *   may have failed to reach the host, or the connection may have died,
+   *   or it may have been aborted.
+   */
+  state(): "closed" | "connecting" | "open" | "idle" | "verifying" | "error" {
+    if (this.s.t == "ready") {
+      return this.s.streamCount() > 0 ? "open" : "idle";
+    }
+    return this.s.t;
+  }
+
+  /**
+   * Returns the error object if the connection is in the "error" state,
+   * `undefined` otherwise.
+   */
+  error(): unknown {
+    if (this.s.t == "error") {
+      return this.s.reason;
+    }
+    return undefined;
+  }
+
+  private s:
+    | StateClosed
+    | StateError
+    | StateConnecting
+    | StateVerifying
+    | StateReady = closed();
+
+  private readonly http2SessionOptions:
+    | http2.ClientSessionOptions
+    | http2.SecureClientSessionOptions
+    | undefined;
+
+  private readonly options: Required<Http2SessionOptions>;
+
+  public constructor(
+    authority: URL | string,
+    pingOptions: Http2SessionOptions,
+    http2SessionOptions:
+      | http2.ClientSessionOptions
+      | http2.SecureClientSessionOptions
+      | undefined
+  ) {
+    this.authority = new URL(authority).origin;
+    this.http2SessionOptions = http2SessionOptions;
+    this.options = {
+      pingIntervalMs: pingOptions.pingIntervalMs ?? Number.POSITIVE_INFINITY,
+      pingTimeoutMs: pingOptions.pingTimeoutMs ?? 1000 * 15,
+      pingIdleConnection: pingOptions.pingIdleConnection ?? false,
+      idleConnectionTimeoutMs:
+        pingOptions.idleConnectionTimeoutMs ?? 1000 * 60 * 5,
+    };
+  }
+
+  async connect(): Promise<"open" | "idle" | "error"> {
+    try {
+      const ready = await this.gotoReady();
+      return ready.streamCount() > 0 ? "open" : "idle";
+    } catch (e) {
+      return "error";
+    }
+  }
+
+  /**
+   * Issue a request.
+   *
+   * This method automatically opens a connection if none exists, and verifies
+   * an existing connection if necessary. It calls http2.ClientHttp2Session.request(),
+   * and keeps track of all open http2.ClientHttp2Stream.
+   *
+   * Clients must call notifyResponseByteRead() whenever they successfully read
+   * data from the http2.ClientHttp2Stream.
+   */
+  async request(
+    method: string,
+    path: string,
+    headers: http2.OutgoingHttpHeaders,
+    options: Omit<http2.ClientSessionRequestOptions, "signal">
+  ): Promise<http2.ClientHttp2Stream> {
+    const ready = await this.gotoReady();
+    const stream = ready.conn.request(
+      {
+        ...headers,
+        ":method": method,
+        ":path": path,
+      },
+      options
+    );
+    ready.registerRequest(stream);
+    return stream;
+  }
+
+  /**
+   * Notify the manager of a successful read from a http2.ClientHttp2Stream.
+   *
+   * Clients must call this function whenever they successfully read data from
+   * a http2.ClientHttp2Stream obtained from request(). This informs the
+   * keep-alive logic that the connection is alive, and prevents it from sending
+   * unnecessary PING frames.
+   */
+  notifyResponseByteRead(stream: http2.ClientHttp2Stream): void {
+    if (this.s.t == "ready") {
+      this.s.responseByteRead(stream);
+    }
+  }
+
+  /**
+   * If there is an open connection, close it. This also closes any open streams.
+   */
+  abort(reason?: Error): void {
+    const err = reason ?? new ConnectError("connection aborted", Code.Canceled);
+    this.s.abort?.(err);
+    this.setState(closedOrError(err));
+  }
+
+  private async gotoReady() {
+    if (this.s.t == "ready") {
+      if (this.s.requiresVerify()) {
+        this.setState(
+          verify(this.s, this.options, this.authority, this.http2SessionOptions)
+        );
+      }
+    } else if (this.s.t == "closed" || this.s.t == "error") {
+      this.setState(connect(this.authority, this.http2SessionOptions));
+    }
+    while (this.s.t !== "ready") {
+      if (this.s.t === "error") {
+        throw this.s.reason;
+      }
+      if (this.s.t === "connecting") {
+        await this.s.conn;
+      }
+      if (this.s.t === "verifying") {
+        await this.s.verified;
+      }
+    }
+    return this.s;
+  }
+
+  private setState(
+    this: Http2SessionManager,
+    state:
+      | StateClosed
+      | StateError
+      | StateConnecting
+      | StateVerifying
+      | StateReady
+  ): void {
+    this.s.onExitState?.();
+    switch (state.t) {
+      case "connecting":
+        state.conn.then(
+          (value) => {
+            this.setState(ready(value, this.options));
+          },
+          (reason) => {
+            this.setState(closedOrError(reason));
+          }
+        );
+        break;
+      case "verifying":
+        state.verified.then(
+          (value) => {
+            if ("t" in value) {
+              this.setState(value);
+            } else {
+              this.setState(ready(value, this.options));
+            }
+          },
+          (reason) => {
+            this.setState(closedOrError(reason));
+          }
+        );
+        break;
+      case "ready":
+        state.onClose = () => this.setState(closed());
+        state.onError = (err) => this.setState(closedOrError(err));
+        break;
+      case "closed":
+        break;
+      case "error":
+        break;
+    }
+    this.s = state;
+  }
+}
+
+interface StateCommon {
+  /**
+   * A unique string that serves as a discriminator for each state type.
+   */
+  readonly t: string;
+  /**
+   * Abort this state, cancelling any work, and terminating any connection.
+   */
+  abort?: (reason?: Error) => void;
+  /**
+   * Called when the manager is leaving this state.
+   */
+  onExitState?: () => void;
+}
+
+/**
+ * The connection is closed, or no connection has been opened yet.
+ */
+interface StateClosed extends StateCommon {
+  readonly t: "closed";
+}
+
+function closed(): StateClosed {
+  return {
+    t: "closed",
+  };
+}
+
+/**
+ * The connection is closed because of a transient error.
+ * A connection may have failed to reach the host, or the connection may have
+ * died, or it may have been aborted.
+ */
+interface StateError extends StateCommon {
+  readonly t: "error";
+  /**
+   * The error.
+   */
+  readonly reason: unknown;
+}
+
+function error(reason: unknown): StateError {
+  return {
+    t: "error",
+    reason,
+  };
+}
+
+function closedOrError(reason: unknown) {
+  const isCancel =
+    reason instanceof ConnectError &&
+    ConnectError.from(reason).code == Code.Canceled;
+  return isCancel ? closed() : error(reason);
+}
+
+/**
+ * The manager is currently establishing a connection.
+ */
+interface StateConnecting extends StateCommon {
+  readonly t: "connecting";
+
+  /**
+   * A promise for the new connection that resolves if the connection was
+   * established, but rejects if the connection failed or the state was aborted.
+   */
+  readonly conn: Promise<http2.ClientHttp2Session>;
+}
+
+function connect(
+  authority: string,
+  http2SessionOptions:
+    | http2.ClientSessionOptions
+    | http2.SecureClientSessionOptions
+    | undefined
+): StateConnecting {
+  let resolve: ((value: http2.ClientHttp2Session) => void) | undefined;
+  let reject: ((reason: unknown) => void) | undefined;
+  const conn = new Promise<http2.ClientHttp2Session>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const newConn = http2.connect(authority, http2SessionOptions);
+  newConn.on("connect", onConnect);
+  newConn.on("error", onError);
+
+  function onConnect() {
+    resolve?.(newConn);
+    cleanup();
+  }
+
+  function onError(err: unknown) {
+    reject?.(err);
+    cleanup();
+  }
+
+  function cleanup() {
+    newConn.off("connect", onConnect);
+    newConn.off("error", onError);
+  }
+
+  return {
+    t: "connecting",
+    conn,
+    abort(reason) {
+      if (!newConn.destroyed) {
+        newConn.destroy(undefined, http2.constants.NGHTTP2_CANCEL);
+      }
+      // According to the documentation, destroy() should immediately terminate
+      // the session and the socket, but we still receive a "connect" event.
+      // We must not resolve a broken connection, so we reject it manually here.
+      reject?.(reason);
+    },
+    onExitState() {
+      cleanup();
+    },
+  } satisfies StateConnecting;
+}
+
+interface StateVerifying extends StateCommon {
+  readonly t: "verifying";
+
+  /**
+   * The existing connection (StateReady) if it has been successfully verified
+   * with a PING frame. A new connection otherwise.
+   */
+  readonly verified: Promise<StateReady | StateConnecting>;
+}
+
+export function verify(
+  stateReady: StateReady,
+  options: Required<Http2SessionOptions>,
+  authority: string,
+  http2SessionOptions:
+    | http2.ClientSessionOptions
+    | http2.SecureClientSessionOptions
+    | undefined
+): StateVerifying {
+  const verified = stateReady.ping().then((success) => {
+    if (success) {
+      return stateReady;
+    }
+    // ping() has destroyed the old connection
+    return connect(authority, http2SessionOptions);
+  });
+  return {
+    t: "verifying",
+    verified,
+    abort(reason) {
+      stateReady.abort?.(reason);
+    },
+  };
+}
+
+interface StateReady extends StateCommon {
+  readonly t: "ready";
+
+  /**
+   * The open connection that is ready to use, but might require verification.
+   */
+  readonly conn: http2.ClientHttp2Session;
+
+  /**
+   * Returns the number of open streams.
+   */
+  streamCount(): number;
+
+  /**
+   * Returns true if the connection should be verified before use, because it
+   * has not received a PING response or response bytes for longer than
+   * verifyAgeMs.
+   */
+  requiresVerify(): boolean;
+
+  /**
+   * Register a stream, so that we can keep track of open streams, and keep the
+   * connection alive with PING frames while streams are open.
+   */
+  registerRequest(stream: http2.ClientHttp2Stream): void;
+
+  /**
+   * Notify the keep-alive logic about received response bytes. A received byte
+   * is proof that the connection is alive, resets the interval for PING frames.
+   */
+  responseByteRead(stream: http2.ClientHttp2Stream): void;
+
+  /**
+   * Send a PING frame, resolve to true if it is responded to in time, resolve
+   * to false otherwise (and closes the connection).
+   */
+  ping(): Promise<boolean>;
+
+  /**
+   * Called when the connection closes without error.
+   */
+  onClose: (() => void) | undefined;
+
+  /**
+   * Called when the connection closes with an error.
+   */
+  onError: ((err: Error) => void) | undefined;
+}
+
+function ready(
+  conn: http2.ClientHttp2Session,
+  options: Required<Http2SessionOptions>
+): StateReady {
+  // the last time we were sure that the connection is alive, via a PING
+  // response, or via received response bytes
+  let lastAliveAt = Date.now();
+  // how many streams are currently open on this session
+  let streamCount = 0;
+  // timer for the keep-alive interval
+  let pingIntervalId: ReturnType<typeof setTimeout> | undefined;
+  // timer for waiting for a PING response
+  let pingTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  // keep track of GOAWAY with ENHANCE_YOUR_CALM and with debug data too_many_pings
+  let receivedGoAwayEnhanceYourCalmTooManyPings = false;
+  // timer for closing connections without open streams, must be initialized
+  let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  resetIdleTimeout();
+
+  const state: StateReady = {
+    t: "ready",
+    conn,
+    streamCount() {
+      return streamCount;
+    },
+    requiresVerify(): boolean {
+      const elapsedMs = Date.now() - lastAliveAt;
+      return elapsedMs > options.pingIntervalMs;
+    },
+    onClose: undefined,
+    onError: undefined,
+    registerRequest(stream: http2.ClientHttp2Stream): void {
+      streamCount++;
+      if (streamCount == 1) {
+        resetPingInterval(); // reset to ping with the appropriate interval for "open"
+        stopIdleTimeout();
+      }
+      stream.once("response", () => {
+        lastAliveAt = Date.now();
+        resetPingInterval();
+      });
+      stream.once("close", () => {
+        streamCount--;
+        if (streamCount == 0) {
+          resetPingInterval(); // reset to ping with the appropriate interval for "idle"
+          resetIdleTimeout();
+        }
+      });
+    },
+    responseByteRead(stream: http2.ClientHttp2Stream) {
+      if (stream.session !== conn) {
+        return;
+      }
+      if (conn.closed || conn.destroyed) {
+        return;
+      }
+      if (streamCount <= 0) {
+        return;
+      }
+      lastAliveAt = Date.now();
+      resetPingInterval();
+    },
+    ping() {
+      return new Promise<boolean>((resolve) => {
+        commonPing(() => resolve(true));
+        conn.once("error", () => resolve(false));
+      });
+    },
+    abort(reason) {
+      if (!conn.destroyed) {
+        conn.once("error", () => {
+          // conn.destroy() may raise an error after onExitState() was called
+          // and our error listeners are removed.
+          // We attach this one to swallow uncaught exceptions.
+        });
+        conn.destroy(reason, http2.constants.NGHTTP2_CANCEL);
+      }
+    },
+    onExitState() {
+      cleanup();
+      this.onError = undefined;
+      this.onClose = undefined;
+    },
+  };
+
+  // start or restart the ping interval
+  function resetPingInterval() {
+    stopPingInterval();
+    if (streamCount > 0 || options.pingIdleConnection) {
+      pingIntervalId = safeSetTimeout(onPingInterval, options.pingIntervalMs);
+    }
+  }
+
+  function stopPingInterval() {
+    clearTimeout(pingIntervalId);
+    clearTimeout(pingTimeoutId);
+  }
+
+  function onPingInterval() {
+    commonPing(resetPingInterval);
+  }
+
+  function commonPing(onSuccess: () => void) {
+    clearTimeout(pingTimeoutId);
+    pingTimeoutId = safeSetTimeout(() => {
+      conn.destroy(
+        new ConnectError("PING timed out", Code.Unavailable),
+        http2.constants.NGHTTP2_CANCEL
+      );
+    }, options.pingTimeoutMs);
+    conn.ping((err, duration) => {
+      clearTimeout(pingTimeoutId);
+      if (err !== null) {
+        // We will receive an ERR_HTTP2_PING_CANCEL here if we destroy the
+        // connection with a pending ping.
+        // We might also see other errors, but they should be picked up by the
+        // "error" event listener.
+        return;
+      }
+      if (duration > options.pingTimeoutMs) {
+        // setTimeout is not precise, and HTTP/2 pings take less than 1ms in
+        // tests.
+        conn.destroy(
+          new ConnectError("PING timed out", Code.Unavailable),
+          http2.constants.NGHTTP2_CANCEL
+        );
+        return;
+      }
+      lastAliveAt = Date.now();
+      onSuccess();
+    });
+  }
+
+  function stopIdleTimeout() {
+    clearTimeout(idleTimeoutId);
+  }
+
+  function resetIdleTimeout() {
+    idleTimeoutId = safeSetTimeout(
+      onIdleTimeout,
+      options.idleConnectionTimeoutMs
+    );
+  }
+
+  function onIdleTimeout() {
+    conn.close();
+    onClose(); // trigger a state change right away so we are not open to races
+  }
+
+  function onGoaway(
+    errorCode: number,
+    lastStreamID: number,
+    opaqueData: Buffer
+  ) {
+    const tooManyPingsAscii = Buffer.from("too_many_pings", "ascii");
+    if (
+      errorCode === http2.constants.NGHTTP2_ENHANCE_YOUR_CALM &&
+      opaqueData.equals(tooManyPingsAscii)
+    ) {
+      // double pingIntervalMs, following the last paragraph of https://github.com/grpc/proposal/blob/0ba0c1905050525f9b0aee46f3f23c8e1e515489/A8-client-side-keepalive.md#basic-keepalive
+      options.pingIntervalMs = options.pingIntervalMs * 2;
+      receivedGoAwayEnhanceYourCalmTooManyPings = true;
+    }
+  }
+
+  function onClose() {
+    cleanup();
+    state.onClose?.();
+  }
+
+  function onError(err: Error) {
+    cleanup();
+    if (receivedGoAwayEnhanceYourCalmTooManyPings) {
+      // We cannot prevent node from destroying session and streams with its own
+      // error that does not carry debug data, but at least we can wrap the error
+      // we surface on the manager.
+      const ce = new ConnectError(
+        `http/2 connection closed with error code ENHANCE_YOUR_CALM (0x${http2.constants.NGHTTP2_ENHANCE_YOUR_CALM.toString(
+          16
+        )}), too_many_pings, doubled the interval`,
+        Code.ResourceExhausted
+      );
+      state.onError?.(ce);
+    } else {
+      state.onError?.(err);
+    }
+  }
+
+  function cleanup() {
+    stopPingInterval();
+    stopIdleTimeout();
+    conn.off("error", onError);
+    conn.off("close", onClose);
+    conn.off("goaway", onGoaway);
+  }
+
+  conn.on("error", onError);
+  conn.on("close", onClose);
+  conn.on("goaway", onGoaway);
+
+  return state;
+}
+
+/**
+ * setTimeout(), but simply ignores values larger than the maximum supported
+ * value (signed 32-bit integer) instead of calling the callback right away.
+ */
+function safeSetTimeout(
+  callback: () => void,
+  ms: number
+): ReturnType<typeof setTimeout> | undefined {
+  if (ms > 0x7fffffff) {
+    return;
+  }
+  return setTimeout(callback, ms);
+}

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -14,7 +14,7 @@
 
 import * as http2 from "http2";
 import { Code, ConnectError } from "@bufbuild/connect";
-import {connectErrorFromNodeReason} from "./node-error.js";
+import { connectErrorFromNodeReason } from "./node-error.js";
 
 export interface Http2SessionOptions {
   /**

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -147,20 +147,19 @@ export class Http2SessionManager {
 
   public constructor(
     authority: URL | string,
-    pingOptions: Http2SessionOptions,
-    http2SessionOptions:
+    pingOptions?: Http2SessionOptions,
+    http2SessionOptions?:
       | http2.ClientSessionOptions
       | http2.SecureClientSessionOptions
-      | undefined
   ) {
     this.authority = new URL(authority).origin;
     this.http2SessionOptions = http2SessionOptions;
     this.options = {
-      pingIntervalMs: pingOptions.pingIntervalMs ?? Number.POSITIVE_INFINITY,
-      pingTimeoutMs: pingOptions.pingTimeoutMs ?? 1000 * 15,
-      pingIdleConnection: pingOptions.pingIdleConnection ?? false,
+      pingIntervalMs: pingOptions?.pingIntervalMs ?? Number.POSITIVE_INFINITY,
+      pingTimeoutMs: pingOptions?.pingTimeoutMs ?? 1000 * 15,
+      pingIdleConnection: pingOptions?.pingIdleConnection ?? false,
       idleConnectionTimeoutMs:
-        pingOptions.idleConnectionTimeoutMs ?? 1000 * 60 * 5,
+        pingOptions?.idleConnectionTimeoutMs ?? 1000 * 60 * 5,
     };
   }
 

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -70,10 +70,14 @@ export interface Http2SessionOptions {
   idleConnectionTimeoutMs?: number;
 }
 
-// TODO document
 /**
- * Manages a HTTP/2 connection with Basic Keepalive as described in
+ * Manage a single HTTP/2 connection and keep it alive with PING frames.
+ *
+ * The logic is based on "Basic Keepalive" described in
  * https://github.com/grpc/proposal/blob/0ba0c1905050525f9b0aee46f3f23c8e1e515489/A8-client-side-keepalive.md#basic-keepalive
+ * as well as the client channel arguments described in
+ * https://github.com/grpc/grpc/blob/8e137e524a1b1da7bbf4603662876d5719563b57/doc/keepalive.md
+ *
  */
 export class Http2SessionManager {
   /**

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -14,6 +14,7 @@
 
 import * as http2 from "http2";
 import { Code, ConnectError } from "@bufbuild/connect";
+import {connectErrorFromNodeReason} from "./node-error.js";
 
 export interface Http2SessionOptions {
   /**
@@ -395,7 +396,7 @@ function connect(
   }
 
   function onError(err: unknown) {
-    reject?.(err);
+    reject?.(connectErrorFromNodeReason(err));
     cleanup();
   }
 
@@ -690,7 +691,7 @@ function ready(
       );
       state.onError?.(ce);
     } else {
-      state.onError?.(err);
+      state.onError?.(connectErrorFromNodeReason(err));
     }
   }
 

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -466,7 +466,7 @@ interface StateReady extends StateCommon {
   /**
    * Returns true if the connection should be verified before use, because it
    * has not received a PING response or response bytes for longer than
-   * verifyAgeMs.
+   * pingIntervalMs.
    */
   requiresVerify(): boolean;
 

--- a/packages/connect-node/src/index.ts
+++ b/packages/connect-node/src/index.ts
@@ -27,3 +27,4 @@ export {
 } from "./node-universal-handler.js";
 
 export { createNodeHttpClient } from "./node-universal-client.js";
+export { Http2SessionManager } from "./http2-session-manager.js";

--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -69,8 +69,6 @@ describe("universal node http client", function () {
         it("should raise Code.Unavailable", async function () {
           const client = createNodeHttpClient({
             httpVersion,
-            baseUrl: "https://unresolvable-host.some.domain",
-            keepSessionAlive: false,
           });
           try {
             await client({

--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -98,10 +98,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise with Code.Canceled", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-        });
+        const client = server.getClient();
         try {
           await client({
             url: server.getUrl(),
@@ -127,9 +124,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
+        const client = server.getClient();
         try {
           await client({
             url: server.getUrl(),
@@ -158,10 +153,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise with Code.Canceled", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-        });
+        const client = server.getClient();
         const res = await client({
           url: server.getUrl(),
           method: "POST",
@@ -192,9 +184,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
+        const client = server.getClient();
         const res = await client({
           url: server.getUrl(),
           method: "POST",
@@ -230,10 +220,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise with Code.Canceled", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-        });
+        const client = server.getClient();
 
         async function* body() {
           yield new Uint8Array(32);
@@ -273,9 +260,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
+        const client = server.getClient();
 
         async function* body() {
           yield new Uint8Array(32);
@@ -319,10 +304,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise with Code.Canceled", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-        });
+        const client = server.getClient();
         const res = await client({
           url: server.getUrl(),
           method: "POST",
@@ -358,9 +340,7 @@ describe("universal node http client", function () {
         })
       );
       it("should reject the response promise", async function () {
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
+        const client = server.getClient();
         const res = await client({
           url: server.getUrl(),
           method: "POST",
@@ -389,12 +369,8 @@ describe("universal node http client", function () {
         http2.createServer(() => (serverReceivedRequest = true))
       );
       it("should raise error with Code.Canceled and never hit the server", async function () {
+        const client = server.getClient();
         const signal = AbortSignal.abort();
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-          keepSessionAlive: false,
-        });
         // client should raise error
         try {
           await client({
@@ -420,10 +396,8 @@ describe("universal node http client", function () {
         http.createServer(() => (serverReceivedRequest = true))
       );
       it("should raise error with Code.Canceled and never hit the server", async function () {
+        const client = server.getClient();
         const signal = AbortSignal.abort();
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
         // client should raise error
         try {
           await client({
@@ -464,12 +438,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled and send RST_STREAM with code CANCEL", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-          keepSessionAlive: false,
-        });
 
         async function* body() {
           await new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -531,10 +501,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
 
         async function* body() {
           await new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -596,12 +564,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled and send RST_STREAM with code CANCEL", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-          keepSessionAlive: false,
-        });
 
         async function* body() {
           yield new Uint8Array(32);
@@ -664,10 +628,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
 
         async function* body() {
           yield new Uint8Array(32);
@@ -731,12 +693,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled and send RST_STREAM with code CANCEL", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "2",
-          baseUrl: server.getUrl(),
-          keepSessionAlive: false,
-        });
 
         const res = await client({
           url: server.getUrl(),
@@ -789,10 +747,8 @@ describe("universal node http client", function () {
       );
       it("should raise error with code canceled", async function () {
         // set up a client that aborts while still streaming the request body
+        const client = server.getClient();
         const ac = new AbortController();
-        const client = createNodeHttpClient({
-          httpVersion: "1.1",
-        });
 
         const res = await client({
           url: server.getUrl(),


### PR DESCRIPTION
This PR adds support [Basic Keepalive](https://github.com/grpc/proposal/blob/0ba0c1905050525f9b0aee46f3f23c8e1e515489/A8-client-side-keepalive.md#basic-keepalive) for HTTP/2 for clients that use one of the transports from `@bufbuild/connect-node`.

It replaces the option `keepSessionAlive`, which is deprecated with this PR.

In it's most simple form, the following example enables regular PINGs every 5 minutes:

```ts
import { createConnectTransport } from "@bufbuild/connect-node";

const transport = createConnectTransport({
  httpVersion: "2",
  baseUrl: "https://demo.connect.build",
  pingIntervalMs: 1000 * 60 * 5,
});
```

With the example above, PING frames are only sent for connections that have open streams (running RPCs). The following options are available to tweak the behavior depending on the requirements.


- `pingIntervalMs?: number`
  The interval to send PING frames to keep a connection alive. The interval is reset whenever a stream receives data. If a PING frame is not responded to within `pingTimeoutMs`, the connection and all open streams close.
 
  By default, no PING frames are sent. If a value is provided, PING frames are sent only for connections that have open streams, unless `pingIdleConnections` is enabled.
 
   Sensible values can be between 10 seconds and 2 hours, depending on your infrastructure.
  
   This option is equivalent to `GRPC_ARG_KEEPALIVE_TIME_MS` in gRPC Core.
 
- `pingIdleConnection?: boolean`
  Enable PING frames for connections that are have no open streams. This option is only effective if a value for pingIntervalMs is provided.
 
  Note that it may not be necessary to enable this option. If a request is made on a connection that has not been used for longer than `pingIntervalMs`, a PING frame is sent to verify that the connection is still alive, and a new connection is opened transparently if necessary.
 
  Defaults to false.
 
  This option is equivalent to `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS` in gRPC Core.
 
- `pingTimeoutMs?: number`
 Timeout for PING frames. If a PING is not answered within this time, the connection is considered dead.
 
  Defaults to 15 seconds. This option is only used if a value for pingIntervalMs is provided.
 
  This option is equivalent to `GRPC_ARG_KEEPALIVE_TIME_MS` in gRPC Core.
 
- `idleConnectionTimeoutMs?: number`
  Automatically close a connection if the time since the last request stream exceeds this value.
  
  Defaults to 15 minutes.
   This option is equivalent to `GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS` of gRPC core.


Sessions and keep-alive are managed by the class `Http2SessionManager` from `@bufbuild/connect-node`. This class can be used to gain control over the session used by the transport by creating it ahead of time, and passing the instance to the transport constructor function. The following example shows how to explicitly close a HTTP/2 connection:

```ts
import { createPromiseClient } from "@bufbuild/connect";
import { createConnectTransport, Http2SessionManager } from "@bufbuild/connect-node";

// create a client, 
const sessionManager = new Http2SessionManager("https://demo.connect.build");
const transport = createConnectTransport({
  httpVersion: "2",
  baseUrl: "https://demo.connect.build",
  sessionManager,
});
const client = createPromiseClient(..., transport);

// make calls with the client

// close the connection
sessionManager.abort();
