### PR TITLE
Ignore unknown JSON fields in Connect unary responses

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 112,895 b | 49,540 b | 13,273 b |
+| connect        | 113,117 b | 49,655 b | 13,321 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 113,117 b | 49,655 b | 13,321 b |
+| connect        | 112,976 b | 49,590 b | 13,282 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -36,6 +36,7 @@ import {
   createClientMethodSerializers,
   createEnvelopeReadableStream,
   createMethodUrl,
+  getJsonOptions,
   encodeEnvelope,
   runStreamingCall,
   runUnaryCall,
@@ -201,13 +202,6 @@ export function createConnectTransport(
             response.headers
           );
 
-          // Ignore unknown fields by default if we need to parse JSON format.
-          // Note this is done automatically via the createClientMethodSerializers call above,
-          // but this is a special path that doesn't use that function so we need to set it
-          // explicitly here.
-          if (options.jsonOptions) {
-            options.jsonOptions.ignoreUnknownFields ??= true;
-          }
           return <UnaryResponse<I, O>>{
             stream: false,
             service,
@@ -217,7 +211,7 @@ export function createConnectTransport(
               ? parse(new Uint8Array(await response.arrayBuffer()))
               : method.O.fromJson(
                   (await response.json()) as JsonValue,
-                  options.jsonOptions
+                  getJsonOptions(options.jsonOptions)
                 ),
             trailer: demuxedTrailer,
           };

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -200,6 +200,14 @@ export function createConnectTransport(
           const [demuxedHeader, demuxedTrailer] = trailerDemux(
             response.headers
           );
+
+          // Ignore unknown fields by default if we need to parse JSON format.
+          // Note this is done automatically via the createClientMethodSerializers call above,
+          // but this is a special path that doesn't use that function so we need to set it
+          // explicitly here.
+          if (options.jsonOptions) {
+            options.jsonOptions.ignoreUnknownFields ??= true;
+          }
           return <UnaryResponse<I, O>>{
             stream: false,
             service,

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -36,6 +36,7 @@ export { runUnaryCall, runStreamingCall } from "./run-call.js";
 export {
   createMethodSerializationLookup,
   createClientMethodSerializers,
+  getJsonOptions,
   limitSerialization,
 } from "./serialization.js";
 export type {

--- a/packages/connect/src/protocol/serialization.spec.ts
+++ b/packages/connect/src/protocol/serialization.spec.ts
@@ -17,6 +17,7 @@ import type { Serialization } from "./serialization.js";
 import {
   createBinarySerialization,
   createJsonSerialization,
+  getJsonOptions,
   limitSerialization,
 } from "./serialization.js";
 import { ConnectError } from "../connect-error.js";
@@ -151,5 +152,20 @@ describe("limitSerialization()", function () {
       ConnectError,
       "[resource_exhausted] message size 6 is larger than configured readMaxBytes 3"
     );
+  });
+});
+
+describe("getJsonOptions()", function () {
+  it("sets ignoreUnknownFields to true if not already set on options object", function () {
+    const opts = getJsonOptions({ emitDefaultValues: true });
+    expect(opts.ignoreUnknownFields).toBeTrue();
+  });
+  it("sets ignoreUnknownFields to true if undefined is passed", function () {
+    const opts = getJsonOptions(undefined);
+    expect(opts.ignoreUnknownFields).toBeTrue();
+  });
+  it("doesn't change ignoreUnknownFields if already set", function () {
+    const opts = getJsonOptions({ ignoreUnknownFields: false });
+    expect(opts.ignoreUnknownFields).toBeFalse();
   });
 });

--- a/packages/connect/src/protocol/serialization.ts
+++ b/packages/connect/src/protocol/serialization.ts
@@ -45,6 +45,17 @@ export interface Serialization<T> {
 }
 
 /**
+ * Returns a Json Options object with defaults set for any properties not provided
+ */
+export function getJsonOptions(
+  options: Partial<JsonReadOptions & JsonWriteOptions> | undefined
+) {
+  const o = { ...options };
+  o.ignoreUnknownFields ??= true;
+  return o;
+}
+
+/**
  * Create an object that provides convenient access to request and response
  * message serialization for a given method.
  *
@@ -215,8 +226,7 @@ export function createJsonSerialization<T extends Message<T>>(
 ): Serialization<T> {
   const textEncoder = options?.textEncoder ?? new TextEncoder();
   const textDecoder = options?.textDecoder ?? new TextDecoder();
-  const o = options ?? {};
-  o.ignoreUnknownFields ??= true;
+  const o = getJsonOptions(options);
   return {
     parse(data: Uint8Array): T {
       try {

--- a/packages/connect/src/protocol/serialization.ts
+++ b/packages/connect/src/protocol/serialization.ts
@@ -46,9 +46,9 @@ export interface Serialization<T> {
 
 /**
  * Sets default JSON serialization options for connect-es.
- * 
- * With standard protobuf JSON serialization, unknown JSON fields are 
- * rejected by default. In connect-es, unknown JSON fields are ignored 
+ *
+ * With standard protobuf JSON serialization, unknown JSON fields are
+ * rejected by default. In connect-es, unknown JSON fields are ignored
  * by default.
  */
 export function getJsonOptions(

--- a/packages/connect/src/protocol/serialization.ts
+++ b/packages/connect/src/protocol/serialization.ts
@@ -45,7 +45,11 @@ export interface Serialization<T> {
 }
 
 /**
- * Returns a Json Options object with defaults set for any properties not provided
+ * Sets default JSON serialization options for connect-es.
+ * 
+ * With standard protobuf JSON serialization, unknown JSON fields are 
+ * rejected by default. In connect-es, unknown JSON fields are ignored 
+ * by default.
  */
 export function getJsonOptions(
   options: Partial<JsonReadOptions & JsonWriteOptions> | undefined


### PR DESCRIPTION
This ignores unknown fields by default if the format is JSON when parsing a response. This was put into place in #642, but this is actually a special case that doesn't follow the code path in #642 and must be handled separately.