### PR TITLE
Pin TypeScript to 5.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.8.8",
-        "typescript": "^5.0.3"
+        "typescript": "5.0.3"
       },
       "engines": {
         "node": ">=16",
@@ -6834,9 +6834,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-node": "^11.1.0",
     "prettier": "^2.8.8",
-    "typescript": "^5.0.3"
+    "typescript": "5.0.3"
   }
 }


### PR DESCRIPTION
This pins Connect-ES to TypeScript 5.0.3 for the time being. The repo is seeing test failures with 5.1 and this will pin to the working version until we can further investigate.

The failing test is `should leave source dangling` in `packages/connect/src/protocol/async-iterable.spec.ts`, which is relying on the `finally` not being called. Upgrading to 5.1 results in `finally` getting invoked and the expected array being of size 2.

FWIW, the 5.1 behavior may actually be the correct behavior and it could be this test is relying on a fixed bug.

For additonal reading, see:

* https://github.com/microsoft/TypeScript/issues/52936
* https://github.com/microsoft/TypeScript/pull/52754
* https://github.com/microsoft/TypeScript/pull/51297
* https://github.com/microsoft/TypeScript/issues/50525