### PR TITLE
Add test coverage for Node.js HTTP/2 idleConnectionTimeoutMs

### DIFF
--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -208,6 +208,30 @@ describe("Http2SessionManager", function () {
     });
   });
 
+  describe("with idleConnectionTimeoutMs", function () {
+    it('should close an idle connection', async function () {
+      const sm = new Http2SessionManager(server.getUrl(), {
+        idleConnectionTimeoutMs: 5 // intentionally short for tests
+      });
+      const req1 = await sm.request("POST", "/", {}, {});
+      await new Promise<void>(resolve => {
+        req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve);
+      });
+      expect(sm.state()).toBe("idle");
+      await new Promise<void>(resolve => setTimeout(resolve, 15)); // wait for idle timeout
+      expect(sm.state())
+          .withContext("connection state after waiting for idle timeout")
+          .toBe("closed");
+
+      // new request should open new connection without errors
+      const req2 = await sm.request("POST", "/", {}, {});
+      expect(sm.state()).toBe("open");
+      await new Promise<void>(resolve => {
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve);
+      });
+    });
+  });
+
   describe("receiving a GOAWAY frame", function () {
     describe("with error ENHANCE_YOUR_CALM and debug data too_many_pings", function () {
       it("should use double the original pingIntervalMs for a second connection", async function () {

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -209,24 +209,24 @@ describe("Http2SessionManager", function () {
   });
 
   describe("with idleConnectionTimeoutMs", function () {
-    it('should close an idle connection', async function () {
+    it("should close an idle connection", async function () {
       const sm = new Http2SessionManager(server.getUrl(), {
-        idleConnectionTimeoutMs: 5 // intentionally short for tests
+        idleConnectionTimeoutMs: 5, // intentionally short for tests
       });
       const req1 = await sm.request("POST", "/", {}, {});
-      await new Promise<void>(resolve => {
+      await new Promise<void>((resolve) => {
         req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve);
       });
       expect(sm.state()).toBe("idle");
-      await new Promise<void>(resolve => setTimeout(resolve, 15)); // wait for idle timeout
+      await new Promise<void>((resolve) => setTimeout(resolve, 15)); // wait for idle timeout
       expect(sm.state())
-          .withContext("connection state after waiting for idle timeout")
-          .toBe("closed");
+        .withContext("connection state after waiting for idle timeout")
+        .toBe("closed");
 
       // new request should open new connection without errors
       const req2 = await sm.request("POST", "/", {}, {});
       expect(sm.state()).toBe("open");
-      await new Promise<void>(resolve => {
+      await new Promise<void>((resolve) => {
         req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve);
       });
     });


### PR DESCRIPTION
Investigating open issues, I noticed we do not have test coverage for the `idleConnectionTimeoutMs` option for HTTP/2 sessions. 

This adds a test to ensure that idle sessions are closed, and that new requests open a new session as expected.