### PR TITLE
Update ConnectError.from to keep the cause

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 113,630 b | 49,881 b | 13,372 b |
+| connect        | 113,771 b | 49,913 b | 13,375 b |
 | grpc-web       | 414,906 b    | 301,127 b    | 53,279 b |

--- a/packages/connect/src/connect-error.spec.ts
+++ b/packages/connect/src/connect-error.spec.ts
@@ -123,6 +123,7 @@ describe("ConnectError", () => {
       expect(got as unknown).toBe(error);
       expect(got.code).toBe(Code.PermissionDenied);
       expect(got.rawMessage).toBe("Not permitted");
+      expect(got.cause).toBeUndefined();
     });
     it("accepts any Error", () => {
       const error: unknown = new Error("Not permitted");
@@ -130,12 +131,14 @@ describe("ConnectError", () => {
       expect(got as unknown).not.toBe(error);
       expect(got.code).toBe(Code.Unknown);
       expect(got.rawMessage).toBe("Not permitted");
+      expect(got.cause).toBe(error);
     });
     it("accepts string value", () => {
       const error: unknown = "Not permitted";
       const got = ConnectError.from(error);
       expect(got.code).toBe(Code.Unknown);
       expect(got.rawMessage).toBe("Not permitted");
+      expect(got.cause).toBe(error);
     });
   });
 });

--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -105,6 +105,8 @@ export class ConnectError extends Error {
    * - For other Errors, return the error message with code Unknown by default.
    * - For other values, return the values String representation as a message,
    *   with the code Unknown by default.
+   * The original value will be used for the "cause" property for the new
+   * ConnectError.
    */
   static from(reason: unknown, code = Code.Unknown): ConnectError {
     if (reason instanceof ConnectError) {
@@ -117,9 +119,15 @@ export class ConnectError extends Error {
         // error object, and translate to the appropriate status code.
         return new ConnectError(reason.message, Code.Canceled);
       }
-      return new ConnectError(reason.message, code);
+      return new ConnectError(
+        reason.message,
+        code,
+        undefined,
+        undefined,
+        reason
+      );
     }
-    return new ConnectError(String(reason), code);
+    return new ConnectError(String(reason), code, undefined, undefined, reason);
   }
 
   /**


### PR DESCRIPTION
ConnectError.from() wraps any error as a ConnectError, unless it already is a ConnectError.

This updates the method to store the original reason in the `cause` property of the newly created ConnectError. 

Closes #715.