### PR TITLE
Avoid type modifiers on import names to support TS older than 4.5

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,7 @@ module.exports = {
             "@typescript-eslint/no-base-to-string": "error",
             "import/no-cycle": "error",
             "import/no-duplicates": "error",
+            "import/consistent-type-specifier-style": ["error", "prefer-top-level"], // TS 4.5 adds type modifiers on import names, but we want to support lower versions
           },
         };
       }),

--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -17,7 +17,8 @@ import * as http from "http";
 import * as https from "https";
 import * as fs from "fs";
 import * as path from "path";
-import { cors, createRouterTransport, type Transport } from "@bufbuild/connect";
+import { cors, createRouterTransport } from "@bufbuild/connect";
+import type { Transport } from "@bufbuild/connect";
 import {
   compressionGzip,
   connectNodeAdapter,

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -21,10 +21,10 @@ import type {
 import type { Interceptor, Transport } from "@bufbuild/connect";
 import type { Compression } from "@bufbuild/connect/protocol";
 import { createTransport } from "@bufbuild/connect/protocol-connect";
-import {
-  type DeprecatedNodeTransportOptions,
-  type NodeTransportOptions,
-  validateNodeTransportOptions,
+import { validateNodeTransportOptions } from "./node-transport-options.js";
+import type {
+  DeprecatedNodeTransportOptions,
+  NodeTransportOptions,
 } from "./node-transport-options.js";
 
 /**

--- a/packages/connect-node/src/grpc-transport.ts
+++ b/packages/connect-node/src/grpc-transport.ts
@@ -21,10 +21,10 @@ import type {
   JsonReadOptions,
   JsonWriteOptions,
 } from "@bufbuild/protobuf";
-import {
-  type DeprecatedNodeTransportOptions,
-  type NodeTransportOptions,
-  validateNodeTransportOptions,
+import { validateNodeTransportOptions } from "./node-transport-options.js";
+import type {
+  DeprecatedNodeTransportOptions,
+  NodeTransportOptions,
 } from "./node-transport-options.js";
 
 /**

--- a/packages/connect-node/src/grpc-web-transport.ts
+++ b/packages/connect-node/src/grpc-web-transport.ts
@@ -21,10 +21,10 @@ import type {
   JsonReadOptions,
   JsonWriteOptions,
 } from "@bufbuild/protobuf";
-import {
-  type DeprecatedNodeTransportOptions,
-  type NodeTransportOptions,
-  validateNodeTransportOptions,
+import { validateNodeTransportOptions } from "./node-transport-options.js";
+import type {
+  DeprecatedNodeTransportOptions,
+  NodeTransportOptions,
 } from "./node-transport-options.js";
 
 /**

--- a/packages/connect-node/src/node-transport-options.ts
+++ b/packages/connect-node/src/node-transport-options.ts
@@ -18,14 +18,10 @@ import type {
 } from "@bufbuild/connect/protocol";
 import { validateReadWriteMaxBytes } from "@bufbuild/connect/protocol";
 import { compressionBrotli, compressionGzip } from "./compression.js";
-import {
-  createNodeHttpClient,
-  type NodeHttp2ClientSessionManager,
-} from "./node-universal-client.js";
-import {
-  Http2SessionManager,
-  type Http2SessionOptions,
-} from "./http2-session-manager.js";
+import { createNodeHttpClient } from "./node-universal-client.js";
+import type { NodeHttp2ClientSessionManager } from "./node-universal-client.js";
+import { Http2SessionManager } from "./http2-session-manager.js";
+import type { Http2SessionOptions } from "./http2-session-manager.js";
 import * as http2 from "http2";
 import * as http from "http";
 import * as https from "https";

--- a/packages/connect-node/src/node-universal-handler.spec.ts
+++ b/packages/connect-node/src/node-universal-handler.spec.ts
@@ -21,8 +21,8 @@ import { getNodeErrorProps } from "./node-error.js";
 import {
   assertByteStreamRequest,
   readAllBytes,
-  type UniversalServerRequest,
 } from "@bufbuild/connect/protocol";
+import type { UniversalServerRequest } from "@bufbuild/connect/protocol";
 
 // Polyfill the Headers API for Node versions < 18
 import "./node-headers-polyfill.js";

--- a/packages/connect-web-test/src/helpers/crosstestserver.ts
+++ b/packages/connect-web-test/src/helpers/crosstestserver.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { type Transport, createRouterTransport } from "@bufbuild/connect";
+import { createRouterTransport } from "@bufbuild/connect";
+import type { Transport } from "@bufbuild/connect";
 import {
   createConnectTransport,
   createGrpcWebTransport,

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -58,27 +58,25 @@ import {
   requireProtocolVersionHeader,
   requireProtocolVersionParam,
 } from "./version.js";
-import {
-  type Compression,
-  compressionNegotiate,
-} from "../protocol/compression.js";
-import {
-  type MethodSerializationLookup,
-  type Serialization,
-  createMethodSerializationLookup,
+import { compressionNegotiate } from "../protocol/compression.js";
+import type { Compression } from "../protocol/compression.js";
+import { createMethodSerializationLookup } from "../protocol/serialization.js";
+import type {
+  MethodSerializationLookup,
+  Serialization,
 } from "../protocol/serialization.js";
+import { validateUniversalHandlerOptions } from "../protocol/universal-handler.js";
+import type { UniversalHandlerOptions } from "../protocol/universal-handler.js";
 import {
-  type UniversalHandlerOptions,
-  validateUniversalHandlerOptions,
-} from "../protocol/universal-handler.js";
-import {
-  type UniversalHandlerFn,
-  type UniversalServerRequest,
-  type UniversalServerResponse,
   assertByteStreamRequest,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
+} from "../protocol/universal.js";
+import type {
+  UniversalHandlerFn,
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "../protocol/universal.js";
 import {
   createAsyncIterable,

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -54,21 +54,19 @@ import { createMethodUrl } from "../protocol/create-method-url.js";
 import type { EnvelopedMessage } from "../protocol/envelope.js";
 import { transformInvokeImplementation } from "../protocol/invoke-implementation.js";
 import type { ProtocolHandlerFactory } from "../protocol/protocol-handler-factory.js";
+import { createMethodSerializationLookup } from "../protocol/serialization.js";
+import type { Serialization } from "../protocol/serialization.js";
+import { validateUniversalHandlerOptions } from "../protocol/universal-handler.js";
+import type { UniversalHandlerOptions } from "../protocol/universal-handler.js";
 import {
-  type Serialization,
-  createMethodSerializationLookup,
-} from "../protocol/serialization.js";
-import {
-  type UniversalHandlerOptions,
-  validateUniversalHandlerOptions,
-} from "../protocol/universal-handler.js";
-import {
-  type UniversalServerRequest,
-  type UniversalServerResponse,
   assertByteStreamRequest,
   uResponseUnsupportedMediaType,
   uResponseMethodNotAllowed,
   uResponseOk,
+} from "../protocol/universal.js";
+import type {
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "../protocol/universal.js";
 
 const protocolName = "grpc-web";

--- a/packages/connect/src/protocol-grpc/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.ts
@@ -50,17 +50,17 @@ import { createMethodUrl } from "../protocol/create-method-url.js";
 import { transformInvokeImplementation } from "../protocol/invoke-implementation.js";
 import type { ProtocolHandlerFactory } from "../protocol/protocol-handler-factory.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
+import { validateUniversalHandlerOptions } from "../protocol/universal-handler.js";
+import type { UniversalHandlerOptions } from "../protocol/universal-handler.js";
 import {
-  type UniversalHandlerOptions,
-  validateUniversalHandlerOptions,
-} from "../protocol/universal-handler.js";
-import {
-  type UniversalServerRequest,
-  type UniversalServerResponse,
   assertByteStreamRequest,
   uResponseUnsupportedMediaType,
   uResponseMethodNotAllowed,
   uResponseOk,
+} from "../protocol/universal.js";
+import type {
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "../protocol/universal.js";
 
 const protocolName = "grpc";

--- a/packages/connect/src/protocol/run-call.spec.ts
+++ b/packages/connect/src/protocol/run-call.spec.ts
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  Int32Value,
-  MethodKind,
-  type ServiceType,
-  StringValue,
-} from "@bufbuild/protobuf";
+import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
+import type { ServiceType } from "@bufbuild/protobuf";
 import { runStreamingCall, runUnaryCall } from "./run-call.js";
 import type {
   StreamRequest,

--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -24,11 +24,13 @@ import { createHandlerFactory as handlerFactoryGrpcWeb } from "./protocol-grpc-w
 import { createHandlerFactory as handlerFactoryGrpc } from "./protocol-grpc/handler-factory.js";
 import { createHandlerFactory as handlerFactoryConnect } from "./protocol-connect/handler-factory.js";
 import {
-  type UniversalHandler,
-  type UniversalHandlerOptions,
   createUniversalMethodHandler,
   createUniversalServiceHandlers,
   validateUniversalHandlerOptions,
+} from "./protocol/universal-handler.js";
+import type {
+  UniversalHandler,
+  UniversalHandlerOptions,
 } from "./protocol/universal-handler.js";
 import type { ProtocolHandlerFactory } from "./protocol/protocol-handler-factory.js";
 


### PR DESCRIPTION
TypeScript 4.5 added support for [type modifiers on import names](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names), but we need to avoid them in our code base for older versions of TypeScript that we intend to support.

This configures the rule [consistent-type-specifier-style](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md) of the eslint "import" plugin to disallow type modifiers for import names.

Fixes https://github.com/bufbuild/connect-es/issues/730.