### PR TITLE
Make modifications for examples transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
 
 ## Ecosystem
 
-* [Connect-ES Examples](https://github.com/connectrpc/examples-es):
+* [connect-es Examples](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
 * [connect-query](https://github.com/bufbuild/connect-query):
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
 
 ## Ecosystem
 
-* [connect-es Examples](https://github.com/connectrpc/examples-es):
+* [examples-es](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
 * [connect-query](https://github.com/bufbuild/connect-query):
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Follow our [10 minute tutorial](https://connectrpc.com/docs/web/getting-started)
 we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
 web interface for ELIZA.
 
-**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/bufbuild/connect-es-integration)),
+**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/connectrpc/examples-es)),
 and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
 We support all modern web browsers that implement the widely available
 [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
@@ -99,7 +99,7 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
 
 ## Ecosystem
 
-* [connect-es-integration](https://github.com/bufbuild/connect-es-integration):
+* [Connect-ES Examples](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
 * [connect-query](https://github.com/bufbuild/connect-query):
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers

--- a/packages/connect-web/README.md
+++ b/packages/connect-web/README.md
@@ -53,5 +53,5 @@ To get started with Connect, head over to the [docs](https://connectrpc.com/docs
 for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
 
 Connect plays nice with Vue, Svelte, Remix, Next.js, Angular and many others. Take a look at
-[our examples](https://github.com/bufbuild/connect-es-integration) for various frameworks.
+[our examples](https://github.com/connectrpc/examples-es) for various frameworks.
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -47,7 +47,7 @@ Follow our [10 minute tutorial](https://connectrpc.com/docs/web/getting-started)
 we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
 web interface for ELIZA.
 
-**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/bufbuild/connect-es-integration)),
+**React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/connectrpc/examples-es)),
 and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
 We support all modern web browsers that implement the widely available
 [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -112,5 +112,4 @@ protoc -I . eliza.proto \
 
 To get started, head over to the [docs](https://connectrpc.com/docs/web/getting-started)
 for a tutorial. You will also find API documentation and best practices there.
-For using Connect with your favorite framework, take a look at
-[connect-es-integration](https://github.com/bufbuild/connect-es-integration).
+For using Connect with your favorite framework, take a look at [Connect-ES Examples](https://github.com/connectrpc/examples-es).


### PR DESCRIPTION
This updates the links to account for the transfer of the examples repo (FKA connect-es-integration) to the connectrpc org.